### PR TITLE
fix(homarr): add custom prestart.sh for secret generation

### DIFF
--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,6 +1,6 @@
 name: Homarr
 package_name: homarr-container
-version: 1.45.3-2
+version: 1.45.3-3
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
 long_description: |
@@ -36,5 +36,3 @@ web_ui:
   protocol: http
 default_config:
   SECRET_ENCRYPTION_KEY: ""
-generate_secrets:
-  SECRET_ENCRYPTION_KEY: hex32

--- a/apps/homarr/prestart.sh
+++ b/apps/homarr/prestart.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Prestart script for homarr-container
+# Custom script to handle SECRET_ENCRYPTION_KEY generation
+set -e
+
+PACKAGE_NAME="homarr-container"
+ETC_DIR="/etc/container-apps/${PACKAGE_NAME}"
+RUN_DIR="/run/container-apps/${PACKAGE_NAME}"
+RUNTIME_ENV="${RUN_DIR}/runtime.env"
+ENV_FILE="${ETC_DIR}/env"
+
+# Create runtime directory
+mkdir -p "$(dirname "$RUNTIME_ENV")"
+
+# Load config values from env files
+set -a
+[ -f "${ETC_DIR}/env.defaults" ] && . "${ETC_DIR}/env.defaults"
+[ -f "${ENV_FILE}" ] && . "${ENV_FILE}"
+set +a
+
+# Generate SECRET_ENCRYPTION_KEY if not set or empty
+if [ -z "$SECRET_ENCRYPTION_KEY" ]; then
+    echo "Generating SECRET_ENCRYPTION_KEY..."
+    SECRET_ENCRYPTION_KEY=$(openssl rand -hex 32)
+    # Persist the generated key to the user env file
+    echo "SECRET_ENCRYPTION_KEY=\"${SECRET_ENCRYPTION_KEY}\"" >> "${ENV_FILE}"
+fi
+
+# Set hostname
+HOSTNAME="$(hostname -s)"
+echo "HOSTNAME=$HOSTNAME" > "$RUNTIME_ENV"
+
+# Compute Homarr URL
+# Use PORT variable if set, otherwise default to 80
+PORT="${PORT:-80}"
+HOMARR_URL="http://${HOSTNAME}.local:${PORT}/"
+echo "HOMARR_URL=$HOMARR_URL" >> "$RUNTIME_ENV"


### PR DESCRIPTION
## Summary

- Add custom `prestart.sh` script that generates `SECRET_ENCRYPTION_KEY` if not set
- Remove `generate_secrets` from `metadata.yaml` (replaced by prestart.sh)
- Bump version to 1.45.3-3

This fixes the Homarr container failing with "Invalid environment variables" error on first install because SECRET_ENCRYPTION_KEY was empty.

## Dependencies

This PR requires [hatlabs/container-packaging-tools#119](https://github.com/hatlabs/container-packaging-tools/pull/119) to be merged first, as it adds support for custom prestart.sh scripts.

## Test plan

- [ ] Merge container-packaging-tools#119 first
- [ ] Build package with updated container-packaging-tools
- [ ] Install on test system
- [ ] Verify SECRET_ENCRYPTION_KEY is generated on first start
- [ ] Verify Homarr starts without "Invalid environment variables" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)