### PR TITLE
feat(homarr): add local icons volume mount

### DIFF
--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ${CONTAINER_DATA_ROOT}/data:/appdata
+      - /usr/share/pixmaps:/app/public/icons:ro
     logging:
       options:
         max-size: 10m

--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,6 +1,6 @@
 name: Homarr
 package_name: homarr-container
-version: 1.45.3-3
+version: 1.45.3-4
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
 long_description: |


### PR DESCRIPTION
## Summary

- Add volume mount `/usr/share/pixmaps:/app/public/icons:ro` to Homarr container
- Enables offline icon serving for the dashboard
- Bump package version to 1.45.3-4

## How It Works

1. Container packages install icons to `/usr/share/pixmaps/<package-name>.png`
2. Homarr serves files from `/app/public/icons/` at the URL path `/icons/`
3. homarr-container-adapter transforms file paths to URLs

## Test Plan

- [ ] Verify Homarr starts correctly with new volume
- [ ] Verify icons are accessible at `/icons/` path
- [ ] Test with an installed container package that has an icon

Closes #2

Part of hatlabs/halos-distro#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)