### PR TITLE
feat(homarr): add asset-server for local static file serving

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -33,3 +33,116 @@ runs:
           fi
         done
         echo "YAML validation passed"
+
+    - name: Start asset-server for security tests
+      shell: bash
+      run: |
+        # Create test environment
+        mkdir -p /tmp/homarr-test
+        mkdir -p /tmp/container-apps/test-container/data
+        mkdir -p /tmp/container-apps/test-container/assets
+        mkdir -p /tmp/pixmaps
+        mkdir -p /tmp/branding
+
+        # Create mock sensitive files (should NOT be accessible)
+        echo "SECRET_DATA" > /tmp/container-apps/test-container/env
+        echo "DB_CONTENT" > /tmp/container-apps/test-container/data/db.sqlite
+
+        # Create mock assets (SHOULD be accessible)
+        echo "ASSET_OK" > /tmp/container-apps/test-container/assets/test.txt
+        echo "ICON_OK" > /tmp/pixmaps/test-icon.png
+
+        # Create nginx config
+        cat > /tmp/homarr-test/nginx-assets.conf << 'EOF'
+        server {
+            listen 80;
+
+            location /icons/ {
+                alias /mnt/pixmaps/;
+                autoindex off;
+            }
+
+            location /branding/ {
+                alias /mnt/branding/;
+                autoindex off;
+            }
+
+            location ~ ^/([^/]+)/assets/(.*)$ {
+                alias /mnt/container-apps/$1/assets/$2;
+                autoindex off;
+            }
+        }
+        EOF
+
+        # Start asset-server container
+        docker run -d --name test-asset-server \
+          -p 8771:80 \
+          -v /tmp/pixmaps:/mnt/pixmaps:ro \
+          -v /tmp/branding:/mnt/branding:ro \
+          -v /tmp/container-apps:/mnt/container-apps:ro \
+          -v /tmp/homarr-test/nginx-assets.conf:/etc/nginx/conf.d/default.conf:ro \
+          nginx:alpine
+
+        # Wait for container to be ready
+        sleep 3
+        docker logs test-asset-server
+
+    - name: Run asset-server security tests
+      shell: bash
+      run: |
+        echo "=== Asset-Server Security Tests ==="
+
+        # Test 1: Icons endpoint should work
+        echo "Test 1: /icons/ endpoint..."
+        status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8771/icons/test-icon.png)
+        if [ "$status" != "200" ]; then
+          echo "FAIL: /icons/test-icon.png returned $status (expected 200)"
+          exit 1
+        fi
+        echo "PASS: /icons/ endpoint works"
+
+        # Test 2: Per-container assets should work
+        echo "Test 2: /<container>/assets/ endpoint..."
+        status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8771/test-container/assets/test.txt)
+        if [ "$status" != "200" ]; then
+          echo "FAIL: /test-container/assets/test.txt returned $status (expected 200)"
+          exit 1
+        fi
+        echo "PASS: /<container>/assets/ endpoint works"
+
+        # Test 3: SECURITY - env file should NOT be accessible
+        echo "Test 3: SECURITY - env file should be blocked..."
+        status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8771/test-container/env)
+        if [ "$status" != "404" ]; then
+          echo "SECURITY FAIL: /test-container/env returned $status (expected 404)"
+          exit 1
+        fi
+        echo "PASS: env file correctly blocked"
+
+        # Test 4: SECURITY - data directory should NOT be accessible
+        echo "Test 4: SECURITY - data directory should be blocked..."
+        status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8771/test-container/data/db.sqlite)
+        if [ "$status" != "404" ]; then
+          echo "SECURITY FAIL: /test-container/data/db.sqlite returned $status (expected 404)"
+          exit 1
+        fi
+        echo "PASS: data directory correctly blocked"
+
+        # Test 5: SECURITY - root of container should NOT be accessible
+        echo "Test 5: SECURITY - container root should be blocked..."
+        status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8771/test-container/)
+        if [ "$status" != "404" ]; then
+          echo "SECURITY FAIL: /test-container/ returned $status (expected 404)"
+          exit 1
+        fi
+        echo "PASS: container root correctly blocked"
+
+        echo ""
+        echo "=== All security tests passed! ==="
+
+    - name: Cleanup test containers
+      if: always()
+      shell: bash
+      run: |
+        docker rm -f test-asset-server 2>/dev/null || true
+        rm -rf /tmp/homarr-test /tmp/container-apps /tmp/pixmaps /tmp/branding 2>/dev/null || true

--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -13,3 +13,18 @@ services:
     logging:
       options:
         max-size: 10m
+
+  asset-server:
+    image: nginx:alpine
+    container_name: homarr-asset-server
+    restart: no
+    ports:
+      - "8771:80"
+    volumes:
+      - /usr/share/pixmaps:/mnt/pixmaps:ro
+      - /usr/share/homarr-branding-halos:/mnt/branding:ro
+      - /var/lib/container-apps:/mnt/container-apps:ro
+      - ${CONTAINER_DATA_ROOT}/nginx-assets.conf:/etc/nginx/conf.d/default.conf:ro
+    logging:
+      options:
+        max-size: 10m

--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   homarr:
     image: ghcr.io/homarr-labs/homarr:v1.45.3
     container_name: homarr
-    restart: no
+    restart: unless-stopped
     ports:
       - "80:7575"
     environment:
@@ -11,13 +11,14 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ${CONTAINER_DATA_ROOT}/data:/appdata
     logging:
+      driver: journald
       options:
-        max-size: 10m
+        tag: "{{.Name}}"
 
   asset-server:
     image: nginx:alpine
     container_name: homarr-asset-server
-    restart: no
+    restart: unless-stopped
     ports:
       - "8771:80"
     volumes:
@@ -26,5 +27,6 @@ services:
       - /var/lib/container-apps:/mnt/container-apps:ro
       - ${CONTAINER_DATA_ROOT}/nginx-assets.conf:/etc/nginx/conf.d/default.conf:ro
     logging:
+      driver: journald
       options:
-        max-size: 10m
+        tag: "{{.Name}}"

--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,6 +1,6 @@
 name: Homarr
 package_name: homarr-container
-version: 1.45.3-3
+version: 1.45.3-4
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
 long_description: |

--- a/apps/homarr/prestart.sh
+++ b/apps/homarr/prestart.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Prestart script for homarr-container
-# Custom script to handle SECRET_ENCRYPTION_KEY generation
+# Custom script to handle SECRET_ENCRYPTION_KEY generation and asset-server config
 set -e
 
 PACKAGE_NAME="homarr-container"
@@ -35,3 +35,37 @@ echo "HOSTNAME=$HOSTNAME" > "$RUNTIME_ENV"
 PORT="${PORT:-80}"
 HOMARR_URL="http://${HOSTNAME}.local:${PORT}/"
 echo "HOMARR_URL=$HOMARR_URL" >> "$RUNTIME_ENV"
+
+# Create nginx config for asset-server
+NGINX_CONF="${CONTAINER_DATA_ROOT}/nginx-assets.conf"
+cat > "$NGINX_CONF" << 'NGINX_EOF'
+server {
+    listen 80;
+
+    # System icons from /usr/share/pixmaps
+    location /icons/ {
+        alias /mnt/pixmaps/;
+        autoindex off;
+        expires 1d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Branding assets from /usr/share/homarr-branding-halos
+    location /branding/ {
+        alias /mnt/branding/;
+        autoindex off;
+        expires 1d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Per-container assets - ONLY exposes /assets/ subdirectory
+    # Example: /signalk-container/assets/bg.png -> /mnt/container-apps/signalk-container/assets/bg.png
+    location ~ ^/([^/]+)/assets/(.*)$ {
+        alias /mnt/container-apps/$1/assets/$2;
+        autoindex off;
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+}
+NGINX_EOF
+echo "Created nginx config at $NGINX_CONF"


### PR DESCRIPTION
## Summary

- Add `asset-server` nginx:alpine sidecar container to serve local assets at port 8771
- Generate nginx config dynamically in prestart.sh
- Bump package version to 1.45.3-4

## Endpoints

| Path | Source | Description |
|------|--------|-------------|
| `/icons/` | `/usr/share/pixmaps` | System icons |
| `/branding/` | `/usr/share/homarr-branding-halos` | HaLOS branding |
| `/<container>/assets/` | `/var/lib/container-apps/<container>/assets/` | Per-container assets |

## Security

The per-container endpoint uses a regex that only exposes the `assets/` subdirectory, protecting config files and data.

## Test Plan

- [ ] Verify asset-server container starts
- [ ] Test icon serving: `curl http://halos.local:8771/icons/homarr-container.png`
- [ ] Test branding serving: `curl http://halos.local:8771/branding/logo.svg`
- [ ] Security test: Verify non-assets paths return 404

Closes #4

Part of hatlabs/halos-distro#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)