### PR TITLE
refactor(homarr): remove deprecated package_name from metadata

### DIFF
--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,4 +1,5 @@
 name: Homarr
+app_id: homarr
 version: 1.45.3-4
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS

--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,5 +1,4 @@
 name: Homarr
-package_name: homarr-container
 version: 1.45.3-4
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
@@ -15,7 +14,6 @@ long_description: |
   - User-customizable layout and organization
   - Quick access to Cockpit and system information
   - 30+ integrations for various services
-
 homepage: https://homarr.dev/
 maintainer: Hat Labs <support@hatlabs.fi>
 license: Apache-2.0

--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -24,7 +24,7 @@ if command -v uvx >/dev/null 2>&1; then
             app_name=$(basename "$app_dir")
             echo "Building package for: $app_name"
             if ! uvx --from git+https://github.com/hatlabs/container-packaging-tools.git \
-                     generate-container-packages -o "$BUILD_DIR" "$app_dir"; then
+                     generate-container-packages -o "$BUILD_DIR" --prefix halos "$app_dir"; then
                 echo "ERROR: Failed to build package for $app_name" >&2
                 exit 1
             fi


### PR DESCRIPTION
## Summary

Remove the deprecated `package_name` field from homarr metadata. The package name is now computed at build time from the directory name.

## Background

The `package_name` field in metadata.yaml is deprecated and ignored by the loader. Package names are now computed automatically from the directory name, making this field redundant.

Part of hatlabs/halos-distro#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)