### PR TITLE
fix(homarr): derive package name from script location

### DIFF
--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,6 +1,6 @@
 name: Homarr
 app_id: homarr
-version: 1.45.3-4
+version: 1.45.3-5
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
 long_description: |

--- a/apps/homarr/prestart.sh
+++ b/apps/homarr/prestart.sh
@@ -3,7 +3,10 @@
 # Custom script to handle SECRET_ENCRYPTION_KEY generation and asset-server config
 set -e
 
-PACKAGE_NAME="homarr-container"
+# Derive package name from script location
+# Script is at /var/lib/container-apps/<package-name>/prestart.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_NAME="$(basename "$SCRIPT_DIR")"
 ETC_DIR="/etc/container-apps/${PACKAGE_NAME}"
 RUN_DIR="/run/container-apps/${PACKAGE_NAME}"
 RUNTIME_ENV="${RUN_DIR}/runtime.env"


### PR DESCRIPTION
## Summary

- Fix hardcoded `PACKAGE_NAME="homarr-container"` in prestart.sh that should be `halos-homarr-container`
- Derive package name dynamically from the script's directory path
- Bump version to 1.45.3-5

## Problem

The `prestart.sh` script had a hardcoded package name that didn't match the actual package name when built with the `halos-` prefix. This caused:
1. Environment files sourced from wrong path (`/etc/container-apps/homarr-container/` instead of `/etc/container-apps/halos-homarr-container/`)
2. nginx config created in wrong location
3. Container startup failure with mount errors

## Solution

Derive the package name from the script's location:
```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
PACKAGE_NAME="$(basename "$SCRIPT_DIR")"
```

This makes the script work correctly regardless of the package name prefix.

## Test plan

- [x] Service starts successfully on halos.local after manual fix
- [ ] CI builds package successfully
- [ ] Fresh install on test system works

🤖 Generated with [Claude Code](https://claude.com/claude-code)