### PR TITLE
refactor: update homarr-branding-halos refs to halos-homarr-branding

### DIFF
--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "8771:80"
     volumes:
       - /usr/share/pixmaps:/mnt/pixmaps:ro
-      - /usr/share/homarr-branding-halos:/mnt/branding:ro
+      - /usr/share/halos-homarr-branding:/mnt/branding:ro
       - /var/lib/container-apps:/mnt/container-apps:ro
       - ${CONTAINER_DATA_ROOT}/nginx-assets.conf:/etc/nginx/conf.d/default.conf:ro
     logging:

--- a/apps/homarr/prestart.sh
+++ b/apps/homarr/prestart.sh
@@ -53,7 +53,7 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # Branding assets from /usr/share/homarr-branding-halos
+    # Branding assets from /usr/share/halos-homarr-branding
     location /branding/ {
         alias /mnt/branding/;
         autoindex off;


### PR DESCRIPTION
## Summary
Update branding package references following the package rename from `homarr-branding-halos` to `halos-homarr-branding` for consistent naming convention (halos- prefix for HaLOS packages).

## Changes
- `apps/homarr/docker-compose.yml` - Updated volume mount path for branding assets
- `apps/homarr/prestart.sh` - Updated nginx config comment

## Related PRs
This is part of a coordinated rename across multiple repositories:
- hatlabs/halos-homarr-branding (repo renamed, PR merged)
- hatlabs/halos-distro#50
- hatlabs/homarr-container-adapter (PR pending)
- hatlabs/halos-metapackages (PR pending)

## Test plan
- [ ] PR checks pass
- [ ] Verify homarr container starts correctly with new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)