### PR TITLE
refactor: move nginx config from prestart.sh to package asset

### DIFF
--- a/apps/homarr/assets/nginx-assets.conf
+++ b/apps/homarr/assets/nginx-assets.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+
+    # System icons from /usr/share/pixmaps
+    location /icons/ {
+        alias /mnt/pixmaps/;
+        autoindex off;
+        expires 1d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Branding assets from /usr/share/halos-homarr-branding
+    location /branding/ {
+        alias /mnt/branding/;
+        autoindex off;
+        expires 1d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Per-container assets - ONLY exposes /assets/ subdirectory
+    # Example: /signalk-container/assets/bg.png -> /mnt/container-apps/signalk-container/assets/bg.png
+    location ~ ^/([^/]+)/assets/(.*)$ {
+        alias /mnt/container-apps/$1/assets/$2;
+        autoindex off;
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+}

--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - /usr/share/pixmaps:/mnt/pixmaps:ro
       - /usr/share/halos-homarr-branding:/mnt/branding:ro
       - /var/lib/container-apps:/mnt/container-apps:ro
-      - ${CONTAINER_DATA_ROOT}/nginx-assets.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./assets/nginx-assets.conf:/etc/nginx/conf.d/default.conf:ro
     logging:
       driver: journald
       options:

--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - /usr/share/pixmaps:/mnt/pixmaps:ro
       - /usr/share/halos-homarr-branding:/mnt/branding:ro
       - /var/lib/container-apps:/mnt/container-apps:ro
-      - ./assets/nginx-assets.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx-assets.conf:/etc/nginx/conf.d/default.conf:ro
     logging:
       driver: journald
       options:

--- a/apps/homarr/prestart.sh
+++ b/apps/homarr/prestart.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Prestart script for homarr-container
-# Custom script to handle SECRET_ENCRYPTION_KEY generation and asset-server config
+# Custom script to handle SECRET_ENCRYPTION_KEY generation and runtime env setup
 set -e
 
 # Derive package name from script location
@@ -38,37 +38,3 @@ echo "HOSTNAME=$HOSTNAME" > "$RUNTIME_ENV"
 PORT="${PORT:-80}"
 HOMARR_URL="http://${HOSTNAME}.local:${PORT}/"
 echo "HOMARR_URL=$HOMARR_URL" >> "$RUNTIME_ENV"
-
-# Create nginx config for asset-server
-NGINX_CONF="${CONTAINER_DATA_ROOT}/nginx-assets.conf"
-cat > "$NGINX_CONF" << 'NGINX_EOF'
-server {
-    listen 80;
-
-    # System icons from /usr/share/pixmaps
-    location /icons/ {
-        alias /mnt/pixmaps/;
-        autoindex off;
-        expires 1d;
-        add_header Cache-Control "public, immutable";
-    }
-
-    # Branding assets from /usr/share/halos-homarr-branding
-    location /branding/ {
-        alias /mnt/branding/;
-        autoindex off;
-        expires 1d;
-        add_header Cache-Control "public, immutable";
-    }
-
-    # Per-container assets - ONLY exposes /assets/ subdirectory
-    # Example: /signalk-container/assets/bg.png -> /mnt/container-apps/signalk-container/assets/bg.png
-    location ~ ^/([^/]+)/assets/(.*)$ {
-        alias /mnt/container-apps/$1/assets/$2;
-        autoindex off;
-        expires 1d;
-        add_header Cache-Control "public";
-    }
-}
-NGINX_EOF
-echo "Created nginx config at $NGINX_CONF"


### PR DESCRIPTION
## Summary

- Move nginx-assets.conf from inline generation in prestart.sh to a static file in assets/ directory
- Update docker-compose.yml to reference the installed asset via relative path
- Remove inline config generation from prestart.sh

## Motivation

This addresses the drawbacks identified in #8:
1. **Package versioning** - nginx config changes are now tracked as part of the Debian package
2. **Config management** - static config file instead of embedded shell script
3. **dpkg conffile handling** - static files get proper upgrade handling

## Dependencies

**⚠️ Do not merge until:**
- [ ] hatlabs/container-packaging-tools#134 is merged and released

This PR requires the `assets/` directory support in container-packaging-tools. Without it, the build will fail because the assets won't be installed.

## Test plan

- [ ] Wait for container-packaging-tools release with assets support
- [ ] Build the package locally to verify nginx-assets.conf is installed
- [ ] Deploy and verify asset-server starts correctly with the config

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)