### PR TITLE
fix(homarr): add command to restore original CMD

### DIFF
--- a/apps/homarr/assets/custom-entrypoint.sh
+++ b/apps/homarr/assets/custom-entrypoint.sh
@@ -15,8 +15,13 @@ TEMPLATE="/etc/nginx/templates/nginx.conf"
 if [ -f "$TEMPLATE" ] && ! grep -q "location /icons/" "$TEMPLATE"; then
     echo "Patching nginx template to serve local assets..."
 
-    # Use awk to insert location blocks before "location / {"
+    # Use awk to insert mime.types and location blocks
     awk '
+    /http \{/ {
+        print
+        print "    include /etc/nginx/mime.types;"
+        next
+    }
     /location \/ \{/ {
         print ""
         print "        # HaLOS: Serve system icons from /usr/share/pixmaps"

--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     container_name: homarr
     restart: unless-stopped
     entrypoint: ["/custom-entrypoint.sh"]
+    command: ["sh", "run.sh"]
     ports:
       - "80:7575"
     environment:

--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,6 +1,6 @@
 name: Homarr
 app_id: homarr
-version: 1.45.3-6
+version: 1.45.3-7
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
 long_description: |


### PR DESCRIPTION
## Summary
Fix container immediately exiting with code 0 after the entrypoint patch.

## Problem
When overriding `entrypoint` in docker-compose, Docker clears the original `CMD` from the base image. This caused the container to:
1. Run custom-entrypoint.sh with empty `$@`
2. Call original entrypoint with empty `$@`
3. Execute `exec "$@"` which does nothing
4. Exit immediately with code 0

## Solution
Add `command: ["sh", "run.sh"]` to explicitly restore the original CMD that the Homarr image expects.

## Test plan
- [ ] Deploy to test device
- [ ] Verify container stays running
- [ ] Verify Homarr dashboard is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)