### PR TITLE
chore(homarr): bump version for homarr.icon fix

### DIFF
--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,6 +1,6 @@
 name: Homarr
 app_id: homarr
-version: 1.45.3-7
+version: 1.45.3-8
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
 long_description: |


### PR DESCRIPTION
## Summary

Bump homarr package version (1.45.3-7 → 1.45.3-8) to trigger rebuild with container-packaging-tools fix that properly generates homarr.icon labels from auto-detected icons.

## Related

- hatlabs/container-packaging-tools#135 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)