### PR TITLE
fix(homarr): add extra_hosts for health check networking

### DIFF
--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     command: ["sh", "run.sh"]
     ports:
       - "80:7575"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY}
     volumes:


### PR DESCRIPTION
## Summary
- Add `extra_hosts: ["host.docker.internal:host-gateway"]` to Homarr's docker-compose.yml
- Enables Homarr to resolve `host.docker.internal` to the host machine's IP
- Required for app health checks (pingUrl) to work correctly

## Context
Homarr runs in a Docker container with bridge networking. When it tries to ping apps for health checks, it needs to reach services running on the host. Without `extra_hosts`, `host.docker.internal` doesn't resolve on native Linux Docker.

**Related PR**: hatlabs/homarr-container-adapter#19 changes `derive_ping_url` to use `host.docker.internal` instead of `localhost`.

## Test plan
- [ ] Deploy updated Homarr container
- [ ] Verify `host.docker.internal` resolves inside container: `docker exec homarr cat /etc/hosts`
- [ ] Verify app health check dots show correct status (not "fetch failed")

🤖 Generated with [Claude Code](https://claude.com/claude-code)