### PR TITLE
feat(traefik): add Traefik container package

### DIFF
--- a/apps/traefik/assets/dynamic/authelia.yml
+++ b/apps/traefik/assets/dynamic/authelia.yml
@@ -1,0 +1,15 @@
+# Authelia ForwardAuth Middleware Configuration
+# This file defines the ForwardAuth middleware for Authelia integration.
+# It is loaded by Traefik's file provider.
+
+http:
+  middlewares:
+    authelia:
+      forwardAuth:
+        address: "http://authelia:9091/api/authz/forward-auth"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - Remote-User
+          - Remote-Groups
+          - Remote-Email
+          - Remote-Name

--- a/apps/traefik/assets/traefik.yml
+++ b/apps/traefik/assets/traefik.yml
@@ -1,0 +1,24 @@
+# Traefik Static Configuration
+# This file is copied to /etc/traefik/traefik.yml
+
+api:
+  dashboard: true
+  insecure: true  # Dashboard accessible on :8080 (not exposed externally)
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: halos-proxy-network
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+
+log:
+  level: INFO

--- a/apps/traefik/config.yml
+++ b/apps/traefik/config.yml
@@ -1,4 +1,6 @@
 version: "1.0"
 
 # Traefik configuration is managed automatically.
-# User-configurable options may be added in future versions.
+# No user configuration required.
+
+groups: []

--- a/apps/traefik/config.yml
+++ b/apps/traefik/config.yml
@@ -1,0 +1,4 @@
+version: "1.0"
+
+# Traefik configuration is managed automatically.
+# User-configurable options may be added in future versions.

--- a/apps/traefik/docker-compose.yml
+++ b/apps/traefik/docker-compose.yml
@@ -8,9 +8,9 @@ services:
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ${CONTAINER_DATA_ROOT}/config/traefik.yml:/etc/traefik/traefik.yml:ro
-      - ${CONTAINER_DATA_ROOT}/config/dynamic:/etc/traefik/dynamic:ro
-      - ${CONTAINER_DATA_ROOT}/data/acme.json:/acme.json
+      - /var/lib/container-apps/traefik-container/assets/traefik.yml:/etc/traefik/traefik.yml:ro
+      - /var/lib/container-apps/traefik-container/assets/dynamic:/etc/traefik/dynamic:ro
+      - ${CONTAINER_DATA_ROOT}/acme.json:/acme.json
     networks:
       - proxy
     logging:

--- a/apps/traefik/docker-compose.yml
+++ b/apps/traefik/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/lib/container-apps/traefik-container/assets/traefik.yml:/etc/traefik/traefik.yml:ro
-      - /var/lib/container-apps/traefik-container/assets/dynamic:/etc/traefik/dynamic:ro
+      - ./traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./dynamic:/etc/traefik/dynamic:ro
       - ${CONTAINER_DATA_ROOT}/acme.json:/acme.json
     networks:
       - proxy

--- a/apps/traefik/docker-compose.yml
+++ b/apps/traefik/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  traefik:
+    image: traefik:v3.6
+    container_name: traefik
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${CONTAINER_DATA_ROOT}/config/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ${CONTAINER_DATA_ROOT}/config/dynamic:/etc/traefik/dynamic:ro
+      - ${CONTAINER_DATA_ROOT}/data/acme.json:/acme.json
+    networks:
+      - proxy
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+
+networks:
+  proxy:
+    name: halos-proxy-network
+    driver: bridge

--- a/apps/traefik/metadata.yaml
+++ b/apps/traefik/metadata.yaml
@@ -15,7 +15,7 @@ long_description: |
   - Dynamic configuration updates without restart
   - Built-in dashboard for monitoring (internal only)
 homepage: https://traefik.io/
-maintainer: Hat Labs <support@hatlabs.fi>
+maintainer: Matti Airas <matti.airas@hatlabs.fi>
 license: MIT
 tags:
   - role::container-app

--- a/apps/traefik/metadata.yaml
+++ b/apps/traefik/metadata.yaml
@@ -1,0 +1,31 @@
+name: Traefik
+app_id: traefik
+version: 3.6.5-1
+upstream_version: 3.6.5
+description: Reverse proxy and load balancer for HaLOS
+long_description: |
+  Traefik is a modern HTTP reverse proxy and load balancer that serves as the
+  central entry point for all HaLOS web traffic. It provides automatic service
+  discovery via Docker labels and enables host-based routing for web applications.
+
+  Features:
+  - Automatic service discovery from Docker containers
+  - Host-based routing (halos.local, auth.halos.local, etc.)
+  - ForwardAuth integration for SSO with Authelia
+  - Dynamic configuration updates without restart
+  - Built-in dashboard for monitoring (internal only)
+homepage: https://traefik.io/
+maintainer: Hat Labs <support@hatlabs.fi>
+license: MIT
+tags:
+  - role::container-app
+  - field::core
+  - category::infrastructure
+  - interface::web
+  - network::proxy
+debian_section: web
+architecture: all
+depends:
+  - docker-ce (>= 20.10) | docker.io (>= 20.10)
+web_ui:
+  enabled: false

--- a/apps/traefik/prestart.sh
+++ b/apps/traefik/prestart.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 # Prestart script for traefik-container
-# Copies static configuration from assets to the config directory
+# Creates acme.json with proper permissions for Let's Encrypt certificates
 set -e
 
 # Derive package name from script location
-# Script is at /var/lib/container-apps/<package-name>/prestart.sh
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PACKAGE_NAME="$(basename "$SCRIPT_DIR")"
 ETC_DIR="/etc/container-apps/${PACKAGE_NAME}"
@@ -15,20 +14,13 @@ set -a
 [ -f "${ETC_DIR}/env" ] && . "${ETC_DIR}/env"
 set +a
 
-ASSETS_DIR="${SCRIPT_DIR}/assets"
-CONFIG_DIR="${CONTAINER_DATA_ROOT}/config"
-DATA_DIR="${CONTAINER_DATA_ROOT}/data"
-
-# Create directory structure
-mkdir -p "${CONFIG_DIR}/dynamic"
-mkdir -p "${DATA_DIR}"
-
-# Copy static configuration files (always overwrite to get updates)
-cp "${ASSETS_DIR}/traefik.yml" "${CONFIG_DIR}/traefik.yml"
-cp "${ASSETS_DIR}/dynamic/authelia.yml" "${CONFIG_DIR}/dynamic/authelia.yml"
+# Create data directory
+mkdir -p "${CONTAINER_DATA_ROOT}"
 
 # Create acme.json with proper permissions if it doesn't exist
-if [ ! -f "${DATA_DIR}/acme.json" ]; then
-    touch "${DATA_DIR}/acme.json"
-    chmod 600 "${DATA_DIR}/acme.json"
+# Traefik requires this file to have 600 permissions
+ACME_FILE="${CONTAINER_DATA_ROOT}/acme.json"
+if [ ! -f "${ACME_FILE}" ]; then
+    touch "${ACME_FILE}"
+    chmod 600 "${ACME_FILE}"
 fi

--- a/apps/traefik/prestart.sh
+++ b/apps/traefik/prestart.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Prestart script for traefik-container
+# Copies static configuration from assets to the config directory
+set -e
+
+# Derive package name from script location
+# Script is at /var/lib/container-apps/<package-name>/prestart.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_NAME="$(basename "$SCRIPT_DIR")"
+ETC_DIR="/etc/container-apps/${PACKAGE_NAME}"
+
+# Load config values from env files
+set -a
+[ -f "${ETC_DIR}/env.defaults" ] && . "${ETC_DIR}/env.defaults"
+[ -f "${ETC_DIR}/env" ] && . "${ETC_DIR}/env"
+set +a
+
+ASSETS_DIR="${SCRIPT_DIR}/assets"
+CONFIG_DIR="${CONTAINER_DATA_ROOT}/config"
+DATA_DIR="${CONTAINER_DATA_ROOT}/data"
+
+# Create directory structure
+mkdir -p "${CONFIG_DIR}/dynamic"
+mkdir -p "${DATA_DIR}"
+
+# Copy static configuration files (always overwrite to get updates)
+cp "${ASSETS_DIR}/traefik.yml" "${CONFIG_DIR}/traefik.yml"
+cp "${ASSETS_DIR}/dynamic/authelia.yml" "${CONFIG_DIR}/dynamic/authelia.yml"
+
+# Create acme.json with proper permissions if it doesn't exist
+if [ ! -f "${DATA_DIR}/acme.json" ]; then
+    touch "${DATA_DIR}/acme.json"
+    chmod 600 "${DATA_DIR}/acme.json"
+fi


### PR DESCRIPTION
## Summary
- Add Traefik v3.6 reverse proxy as core infrastructure for HaLOS SSO
- Docker provider for automatic service discovery via labels
- File provider for dynamic configuration (Authelia ForwardAuth middleware)
- Creates `halos-proxy-network` for inter-container communication
- Prestart script copies config files and creates acme.json with proper permissions

## Test plan
- [ ] Package builds successfully with container-packaging-tools
- [ ] Container starts and creates halos-proxy-network
- [ ] Traefik dashboard accessible on port 8080 (internal only)
- [ ] Can route to a test container with Traefik labels

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)