### PR TITLE
feat(authelia): add Authelia container package

### DIFF
--- a/apps/authelia/assets/configuration.yml.template
+++ b/apps/authelia/assets/configuration.yml.template
@@ -1,0 +1,63 @@
+# Authelia Configuration for HaLOS
+# This template is processed by prestart.sh to inject generated secrets
+
+theme: auto
+
+server:
+  address: tcp://0.0.0.0:9091/
+
+log:
+  level: info
+
+authentication_backend:
+  file:
+    path: /data/users_database.yml
+    password:
+      algorithm: argon2id
+      argon2:
+        variant: argon2id
+        iterations: 3
+        memory: 65536
+        parallelism: 4
+        key_length: 32
+        salt_length: 16
+
+session:
+  secret: '${SESSION_SECRET}'
+  cookies:
+    - domain: '${HALOS_DOMAIN}'
+      authelia_url: 'http://auth.${HALOS_DOMAIN}'
+      default_redirection_url: 'http://${HALOS_DOMAIN}'
+
+storage:
+  local:
+    path: /data/db.sqlite3
+
+notifier:
+  filesystem:
+    filename: /data/notification.txt
+
+access_control:
+  default_policy: one_factor
+
+identity_providers:
+  oidc:
+    hmac_secret: '${OIDC_HMAC_SECRET}'
+    jwks:
+      - key: |
+          ${OIDC_PRIVATE_KEY}
+    clients:
+      - client_id: homarr
+        client_name: Homarr Dashboard
+        client_secret: '${HOMARR_CLIENT_SECRET}'
+        public: false
+        authorization_policy: one_factor
+        redirect_uris:
+          - 'http://${HALOS_DOMAIN}/api/auth/callback/oidc'
+        scopes:
+          - openid
+          - profile
+          - groups
+          - email
+        consent_mode: implicit
+        token_endpoint_auth_method: client_secret_post

--- a/apps/authelia/config.yml
+++ b/apps/authelia/config.yml
@@ -11,6 +11,7 @@ groups:
         label: Timezone
         type: string
         default: UTC
+        required: false
         description: |
           Timezone for Authelia logs and session timestamps.
           Example: Europe/Helsinki, America/New_York

--- a/apps/authelia/config.yml
+++ b/apps/authelia/config.yml
@@ -1,0 +1,24 @@
+version: "1.0"
+
+# Authelia configuration
+# Most settings are managed automatically. Domain can be customized.
+
+groups:
+  - id: general
+    label: General Settings
+    fields:
+      - id: HALOS_DOMAIN
+        label: Domain
+        type: string
+        default: halos.local
+        description: |
+          The domain for Authelia cookies and redirects.
+          Must match the domain used by Traefik and mDNS publisher.
+
+      - id: TZ
+        label: Timezone
+        type: string
+        default: UTC
+        description: |
+          Timezone for Authelia logs and session timestamps.
+          Example: Europe/Helsinki, America/New_York

--- a/apps/authelia/config.yml
+++ b/apps/authelia/config.yml
@@ -1,20 +1,12 @@
 version: "1.0"
 
 # Authelia configuration
-# Most settings are managed automatically. Domain can be customized.
+# Domain is automatically derived from the system hostname: <hostname>.local
 
 groups:
   - id: general
     label: General Settings
     fields:
-      - id: HALOS_DOMAIN
-        label: Domain
-        type: string
-        default: halos.local
-        description: |
-          The domain for Authelia cookies and redirects.
-          Must match the domain used by Traefik and mDNS publisher.
-
       - id: TZ
         label: Timezone
         type: string

--- a/apps/authelia/docker-compose.yml
+++ b/apps/authelia/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: authelia
     restart: unless-stopped
     volumes:
-      - ${CONTAINER_DATA_ROOT}/data:/data
+      - ${CONTAINER_DATA_ROOT}/data:/config
     environment:
       - TZ=${TZ:-UTC}
     networks:

--- a/apps/authelia/docker-compose.yml
+++ b/apps/authelia/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  authelia:
+    image: authelia/authelia:4.39
+    container_name: authelia
+    restart: unless-stopped
+    volumes:
+      - ${CONTAINER_DATA_ROOT}/data:/data
+    environment:
+      - TZ=${TZ:-UTC}
+    networks:
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.authelia.rule=Host(`auth.${HALOS_DOMAIN:-halos.local}`)
+      - traefik.http.routers.authelia.entrypoints=web
+      - traefik.http.services.authelia.loadbalancer.server.port=9091
+      - halos.subdomain=auth
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+
+networks:
+  proxy:
+    name: halos-proxy-network
+    external: true

--- a/apps/authelia/metadata.yaml
+++ b/apps/authelia/metadata.yaml
@@ -17,7 +17,7 @@ long_description: |
   Authelia integrates with Traefik reverse proxy to provide unified
   authentication across all HaLOS web interfaces.
 homepage: https://www.authelia.com/
-maintainer: Hat Labs <support@hatlabs.fi>
+maintainer: Matti Airas <matti.airas@hatlabs.fi>
 license: Apache-2.0
 tags:
   - role::container-app

--- a/apps/authelia/metadata.yaml
+++ b/apps/authelia/metadata.yaml
@@ -29,7 +29,7 @@ debian_section: admin
 architecture: all
 depends:
   - docker-ce (>= 20.10) | docker.io (>= 20.10)
-  - traefik-container
+  - halos-traefik-container
 web_ui:
   enabled: true
   port: 9091

--- a/apps/authelia/metadata.yaml
+++ b/apps/authelia/metadata.yaml
@@ -1,0 +1,37 @@
+name: Authelia
+app_id: authelia
+version: 4.39.15-1
+upstream_version: 4.39.15
+description: Identity provider for HaLOS Single Sign-On
+long_description: |
+  Authelia is a lightweight authentication and authorization server that
+  provides Single Sign-On (SSO) for HaLOS web applications.
+
+  Features:
+  - OpenID Connect (OIDC) provider for native application integration
+  - Forward Auth for applications without native OIDC support
+  - File-based user database (no external database required)
+  - Session management with secure cookies
+  - Low memory footprint (~30-50 MB RAM)
+
+  Authelia integrates with Traefik reverse proxy to provide unified
+  authentication across all HaLOS web interfaces.
+homepage: https://www.authelia.com/
+maintainer: Hat Labs <support@hatlabs.fi>
+license: Apache-2.0
+tags:
+  - role::container-app
+  - field::core
+  - category::security
+  - interface::web
+  - auth::oidc
+debian_section: admin
+architecture: all
+depends:
+  - docker-ce (>= 20.10) | docker.io (>= 20.10)
+  - traefik-container
+web_ui:
+  enabled: true
+  port: 9091
+  path: /
+  protocol: http

--- a/apps/authelia/prestart.sh
+++ b/apps/authelia/prestart.sh
@@ -14,8 +14,8 @@ set -a
 [ -f "${ETC_DIR}/env" ] && . "${ETC_DIR}/env"
 set +a
 
-ASSETS_DIR="${SCRIPT_DIR}/assets"
 DATA_DIR="${CONTAINER_DATA_ROOT}/data"
+TEMPLATE_FILE="${SCRIPT_DIR}/configuration.yml.template"
 SECRETS_FILE="${DATA_DIR}/secrets.env"
 CONFIG_FILE="${DATA_DIR}/configuration.yml"
 
@@ -69,7 +69,7 @@ process_template() {
 
     # Read template
     local template
-    template=$(cat "${ASSETS_DIR}/configuration.yml.template")
+    template=$(cat "${TEMPLATE_FILE}")
 
     # Indent private key for YAML (8 spaces)
     local indented_key

--- a/apps/authelia/prestart.sh
+++ b/apps/authelia/prestart.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Prestart script for authelia-container
+# Generates secrets on first boot and processes configuration template
+set -e
+
+# Derive package name from script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_NAME="$(basename "$SCRIPT_DIR")"
+ETC_DIR="/etc/container-apps/${PACKAGE_NAME}"
+
+# Load config values from env files
+set -a
+[ -f "${ETC_DIR}/env.defaults" ] && . "${ETC_DIR}/env.defaults"
+[ -f "${ETC_DIR}/env" ] && . "${ETC_DIR}/env"
+set +a
+
+ASSETS_DIR="${SCRIPT_DIR}/assets"
+DATA_DIR="${CONTAINER_DATA_ROOT}/data"
+SECRETS_FILE="${DATA_DIR}/secrets.env"
+CONFIG_FILE="${DATA_DIR}/configuration.yml"
+
+# Create data directory
+mkdir -p "${DATA_DIR}"
+
+# Generate secrets on first boot
+generate_secrets() {
+    echo "Generating Authelia secrets..."
+
+    # Generate random secrets
+    SESSION_SECRET=$(openssl rand -hex 32)
+    OIDC_HMAC_SECRET=$(openssl rand -hex 32)
+    HOMARR_CLIENT_SECRET=$(openssl rand -hex 32)
+
+    # Generate RSA private key for OIDC JWT signing
+    OIDC_PRIVATE_KEY=$(openssl genrsa 4096 2>/dev/null)
+
+    # Save secrets to file
+    cat > "${SECRETS_FILE}" << EOF
+SESSION_SECRET="${SESSION_SECRET}"
+OIDC_HMAC_SECRET="${OIDC_HMAC_SECRET}"
+HOMARR_CLIENT_SECRET="${HOMARR_CLIENT_SECRET}"
+EOF
+
+    # Save private key separately (multi-line)
+    echo "${OIDC_PRIVATE_KEY}" > "${DATA_DIR}/oidc_private_key.pem"
+
+    # Restrict permissions
+    chmod 600 "${SECRETS_FILE}" "${DATA_DIR}/oidc_private_key.pem"
+
+    echo "Secrets generated successfully"
+}
+
+# Load or generate secrets
+if [ ! -f "${SECRETS_FILE}" ]; then
+    generate_secrets
+fi
+
+# Load secrets
+. "${SECRETS_FILE}"
+OIDC_PRIVATE_KEY=$(cat "${DATA_DIR}/oidc_private_key.pem")
+
+# Set domain default
+HALOS_DOMAIN="${HALOS_DOMAIN:-halos.local}"
+
+# Process configuration template
+process_template() {
+    echo "Processing Authelia configuration template..."
+
+    # Read template
+    local template
+    template=$(cat "${ASSETS_DIR}/configuration.yml.template")
+
+    # Indent private key for YAML (8 spaces)
+    local indented_key
+    indented_key=$(echo "${OIDC_PRIVATE_KEY}" | sed 's/^/          /')
+
+    # Substitute variables
+    template="${template//\$\{SESSION_SECRET\}/${SESSION_SECRET}}"
+    template="${template//\$\{OIDC_HMAC_SECRET\}/${OIDC_HMAC_SECRET}}"
+    template="${template//\$\{HOMARR_CLIENT_SECRET\}/${HOMARR_CLIENT_SECRET}}"
+    template="${template//\$\{HALOS_DOMAIN\}/${HALOS_DOMAIN}}"
+
+    # Handle private key separately (multi-line)
+    # Use awk for multi-line substitution
+    echo "${template}" | awk -v key="${indented_key}" '
+        /\$\{OIDC_PRIVATE_KEY\}/ {
+            sub(/\$\{OIDC_PRIVATE_KEY\}/, key)
+        }
+        { print }
+    ' > "${CONFIG_FILE}"
+
+    chmod 600 "${CONFIG_FILE}"
+    echo "Configuration generated at ${CONFIG_FILE}"
+}
+
+# Always regenerate config (in case template or domain changed)
+process_template
+
+# Create empty users database if it doesn't exist
+# This will be populated by homarr-container-adapter credential sync
+if [ ! -f "${DATA_DIR}/users_database.yml" ]; then
+    echo "Creating empty users database..."
+    cat > "${DATA_DIR}/users_database.yml" << 'EOF'
+# Authelia Users Database
+# This file is managed by homarr-container-adapter
+# Manual edits may be overwritten
+
+users: {}
+EOF
+    chmod 600 "${DATA_DIR}/users_database.yml"
+fi
+
+echo "Authelia prestart complete"

--- a/apps/authelia/prestart.sh
+++ b/apps/authelia/prestart.sh
@@ -59,8 +59,9 @@ fi
 . "${SECRETS_FILE}"
 OIDC_PRIVATE_KEY=$(cat "${DATA_DIR}/oidc_private_key.pem")
 
-# Set domain default
-HALOS_DOMAIN="${HALOS_DOMAIN:-halos.local}"
+# Auto-detect domain from hostname (matches mDNS publisher)
+HOSTNAME_SHORT=$(hostname -s 2>/dev/null || hostname | cut -d. -f1)
+HALOS_DOMAIN="${HOSTNAME_SHORT}.local"
 
 # Process configuration template
 process_template() {


### PR DESCRIPTION
## Summary
- Add Authelia v4.39 identity provider for HaLOS Single Sign-On
- OIDC provider with Homarr client pre-configured
- File-based user database (populated by homarr-container-adapter)
- Prestart script generates cryptographic secrets on first boot
- Traefik labels for `auth.halos.local` routing
- mDNS subdomain label (`halos.subdomain=auth`) for automatic discovery

## Secrets Generated on First Boot
- Session secret (32 bytes hex)
- OIDC HMAC secret (32 bytes hex)
- RSA 4096 private key for JWT signing
- Homarr OIDC client secret (32 bytes hex)

## Test plan
- [ ] Package builds with container-packaging-tools
- [ ] Secrets auto-generated on first boot
- [ ] Container starts and joins halos-proxy-network
- [ ] Login page accessible at auth.halos.local
- [ ] OIDC discovery endpoint (`/.well-known/openid-configuration`) returns valid config
- [ ] Configuration template processing works correctly

## Dependencies
- Depends on Traefik (#18) for routing
- Depends on mDNS publisher (#20) for subdomain resolution

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)