### PR TITLE
fix(mdns-publisher): update image to v0.1.1

### DIFF
--- a/apps/mdns-publisher/docker-compose.yml
+++ b/apps/mdns-publisher/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mdns-publisher:
-    image: ghcr.io/hatlabs/halos-mdns-publisher:0.1.0
+    image: ghcr.io/hatlabs/halos-mdns-publisher:0.1.1
     container_name: mdns-publisher
     restart: unless-stopped
     network_mode: host


### PR DESCRIPTION
## Summary
- Update halos-mdns-publisher image from v0.1.0 to v0.1.1

The mdns-publisher package was added in PR #24 but referenced the older v0.1.0 image. The halos-mdns-publisher repository is now at v0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)