### PR TITLE
fix(mdns-publisher): add required groups field to config.yml

### DIFF
--- a/apps/mdns-publisher/config.yml
+++ b/apps/mdns-publisher/config.yml
@@ -3,3 +3,5 @@ version: "1.0"
 # mDNS Publisher configuration
 # Domain is automatically derived from the system hostname: <hostname>.local
 # No user configuration required.
+
+groups: []


### PR DESCRIPTION
## Summary
- Add required `groups: []` field to mdns-publisher config.yml

The container-packaging-tools validator requires a `groups` field in config.yml files. This was missing from the mdns-publisher package, causing CI build failures.

Closes the CI failure from https://github.com/hatlabs/halos-core-containers/actions/runs/20398474403

🤖 Generated with [Claude Code](https://claude.com/claude-code)