### PR TITLE
fix(homarr): enable adapter integration with OIDC

### DIFF
--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       - AUTH_OIDC_CLIENT_NAME=${AUTH_OIDC_CLIENT_NAME:-}
       - AUTH_OIDC_SCOPE_OVERWRITE=${AUTH_OIDC_SCOPE_OVERWRITE:-}
       - AUTH_LOGOUT_REDIRECT_URL=${AUTH_LOGOUT_REDIRECT_URL}
+    ports:
+      # Expose to localhost only for homarr-container-adapter
+      - "127.0.0.1:7575:7575"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ${CONTAINER_DATA_ROOT}/data:/appdata

--- a/apps/homarr/prestart.sh
+++ b/apps/homarr/prestart.sh
@@ -48,9 +48,9 @@ echo "HOMARR_URL=$HOMARR_URL" >> "$RUNTIME_ENV"
 # Configure SSO with Authelia (enabled by default)
 echo "Configuring SSO with Authelia..."
 
-# Enable OIDC authentication
+# Enable both credentials (for adapter) and OIDC (for users) authentication
 if ! grep -q "^AUTH_PROVIDERS=" "${ENV_FILE}" 2>/dev/null; then
-    echo "AUTH_PROVIDERS=\"oidc\"" >> "${ENV_FILE}"
+    echo "AUTH_PROVIDERS=\"credentials,oidc\"" >> "${ENV_FILE}"
 fi
 
 # Set OIDC issuer URL


### PR DESCRIPTION
## Summary
- Expose port 7575 to localhost for homarr-container-adapter
- Enable both `credentials` and `oidc` auth providers

## Context
The homarr-container-adapter needs direct HTTP access to Homarr on port 7575 to perform:
- First-boot setup (onboarding, default board creation)
- App sync (registry apps to dashboard)

With OIDC-only authentication, the adapter cannot authenticate because:
1. It uses credentials auth internally
2. OIDC redirects would require following HTTPS redirects with self-signed certs

Enabling both providers allows:
- **Adapter**: authenticates via credentials for internal API calls
- **Users**: authenticate via OIDC (Authelia) for web access

The port is exposed to `127.0.0.1` only, so it's not accessible from the network.

## Related
- Companion PR: https://github.com/hatlabs/homarr-container-adapter/pull/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)