### PR TITLE
feat(homarr): upgrade to v1.47.0 and add HTTPS support

### DIFF
--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   homarr:
-    image: ghcr.io/homarr-labs/homarr:v1.45.3
+    image: ghcr.io/homarr-labs/homarr:v1.47.0
     container_name: homarr
     restart: unless-stopped
     entrypoint: ["/custom-entrypoint.sh"]
@@ -33,8 +33,13 @@ services:
       - proxy
     labels:
       - traefik.enable=true
+      # HTTP router (redirects to HTTPS)
       - traefik.http.routers.homarr.rule=Host(`${HALOS_DOMAIN}`)
       - traefik.http.routers.homarr.entrypoints=web
+      # HTTPS router
+      - traefik.http.routers.homarr-secure.rule=Host(`${HALOS_DOMAIN}`)
+      - traefik.http.routers.homarr-secure.entrypoints=websecure
+      - traefik.http.routers.homarr-secure.tls=true
       - traefik.http.services.homarr.loadbalancer.server.port=7575
     logging:
       driver: journald

--- a/apps/homarr/prestart.sh
+++ b/apps/homarr/prestart.sh
@@ -23,7 +23,8 @@ mkdir -p "$(dirname "$RUNTIME_ENV")"
 
 # Initialize Homarr database from seed if not present
 # The seed database contains pre-configured settings and bootstrap API key
-HOMARR_DB="${DATA_DIR}/data/db.sqlite3"
+# Note: Homarr v1.x uses /appdata/db/db.sqlite inside container
+HOMARR_DB="${DATA_DIR}/data/db/db.sqlite"
 if [ ! -f "$HOMARR_DB" ] && [ -f "$SEED_DB" ]; then
     echo "Initializing Homarr database from seed..."
     mkdir -p "$(dirname "$HOMARR_DB")"


### PR DESCRIPTION
## Summary

- Upgrade Homarr from v1.45.3 to v1.47.0
- Add HTTPS router labels for Traefik (`homarr-secure`)
- Fix database path in prestart.sh to match Homarr v1.x structure

## Changes

### docker-compose.yml
- Image tag: `v1.45.3` → `v1.47.0`
- Added Traefik labels for HTTPS:
  - `traefik.http.routers.homarr-secure.rule`
  - `traefik.http.routers.homarr-secure.entrypoints=websecure`
  - `traefik.http.routers.homarr-secure.tls=true`

### prestart.sh
- Fixed database path: `data/db.sqlite3` → `data/db/db.sqlite`

## Test plan

- [x] Tested on halos.local

🤖 Generated with [Claude Code](https://claude.com/claude-code)