### PR TITLE
fix(homarr): use hatlabs fork until upstream PR is merged

### DIFF
--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   homarr:
-    image: ghcr.io/homarr-labs/homarr:v1.47.0
+    # Using hatlabs fork until homarr-labs/homarr#4372 is merged
+    image: ghcr.io/hatlabs/homarr:api-key-test
     container_name: homarr
     restart: unless-stopped
     entrypoint: ["/custom-entrypoint.sh"]


### PR DESCRIPTION
## Summary

Switch Homarr image from `ghcr.io/homarr-labs/homarr:v1.47.0` to `ghcr.io/hatlabs/homarr:api-key-test` until [homarr-labs/homarr#4372](https://github.com/homarr-labs/homarr/pull/4372) is merged upstream.

## Changes

- Use `ghcr.io/hatlabs/homarr:api-key-test` image
- Added comment explaining the temporary fork usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)