### PR TITLE
fix(traefik): add host.docker.internal for host networking apps

### DIFF
--- a/apps/traefik/docker-compose.yml
+++ b/apps/traefik/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - ${CONTAINER_DATA_ROOT}/acme.json:/acme.json
     networks:
       - proxy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     logging:
       driver: journald
       options:


### PR DESCRIPTION
## Summary

- Adds `extra_hosts: host.docker.internal:host-gateway` to Traefik docker-compose
- Enables routing to containers using `network_mode: host` (e.g., Signal K)

## Problem

Traefik returns 502 Bad Gateway when trying to route to host networking apps because `host.docker.internal` is not resolvable inside the container.

## Solution

Add the Docker-standard `extra_hosts` mapping that resolves `host.docker.internal` to the host gateway IP.

## Test plan

- [ ] Deploy updated Traefik container on test device
- [ ] Verify Signal K (host networking) accessible via `signalk.halos.local`

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)