### PR TITLE
docs: update SSO documentation to use routing schema

### DIFF
--- a/docs/SSO_ARCHITECTURE.md
+++ b/docs/SSO_ARCHITECTURE.md
@@ -397,7 +397,7 @@ halos-core-containers/
 │   │
 │   └── homarr/
 │       ├── docker-compose.yml
-│       ├── metadata.yaml                # traefik.auth: oidc
+│       ├── metadata.yaml                # routing.auth.mode: oidc
 │       └── prestart.sh                  # OIDC env setup
 │
 └── docs/
@@ -407,20 +407,21 @@ halos-core-containers/
 
 ## Integration via metadata.yaml
 
-Applications declare their SSO integration in `metadata.yaml`:
+Applications declare their SSO integration in `metadata.yaml` using the `routing` key:
 
 ```yaml
 # Example: Forward Auth app with custom headers
 name: Grafana
 app_id: grafana
 # ...
-traefik:
+routing:
   subdomain: grafana
-  auth: forward_auth
-  forward_auth:
-    headers:
-      Remote-User: X-WEBAUTH-USER
-      Remote-Groups: X-WEBAUTH-GROUPS
+  auth:
+    mode: forward_auth
+    forward_auth:
+      headers:
+        Remote-User: X-WEBAUTH-USER
+        Remote-Groups: X-WEBAUTH-GROUPS
 ```
 
 ```yaml
@@ -428,14 +429,10 @@ traefik:
 name: Homarr
 app_id: homarr
 # ...
-traefik:
+routing:
   subdomain: ""  # Empty = root domain ({hostname}.local)
-  auth: oidc
-  oidc:
-    client_name: Homarr Dashboard
-    scopes: [openid, profile, email, groups]
-    redirect_path: /api/auth/callback/oidc
-    consent_mode: implicit
+  auth:
+    mode: oidc
 ```
 
 ```yaml
@@ -443,9 +440,10 @@ traefik:
 name: AvNav
 app_id: avnav
 # ...
-traefik:
+routing:
   subdomain: avnav
-  auth: none
+  auth:
+    mode: none
 ```
 
 ```yaml
@@ -453,11 +451,14 @@ traefik:
 name: Signal K
 app_id: signalk-server
 # ...
-traefik:
+routing:
   subdomain: signalk
-  auth: forward_auth
+  auth:
+    mode: forward_auth
   host_port: 3000  # Traefik routes to host:3000
 ```
+
+**Note**: The deprecated `traefik:` key is no longer supported. Use `routing:` instead.
 
 ## Security Considerations
 

--- a/docs/SSO_SPEC.md
+++ b/docs/SSO_SPEC.md
@@ -168,36 +168,29 @@ Authelia requires passwords in argon2id format. The credential sync process must
 
 ## App Metadata Configuration
 
-Applications declare SSO configuration in their `metadata.yaml`:
+Applications declare SSO configuration in their `metadata.yaml` using the `routing` key:
 
 ```yaml
-traefik:
+routing:
   subdomain: myapp          # Optional, defaults to app_id
-  auth: forward_auth        # forward_auth (default) | oidc | none
+  auth:
+    mode: forward_auth      # forward_auth (default) | oidc | none
 
-  # Optional: customize auth headers for forward_auth
-  # Maps Authelia header names to what the app expects
-  # Default: Remote-User, Remote-Groups, Remote-Email, Remote-Name (passed as-is)
-  forward_auth:
-    headers:
-      Remote-User: X-Forwarded-User      # Authelia sends Remote-User, app receives X-Forwarded-User
-      Remote-Groups: X-Forwarded-Groups
-      Remote-Email: X-Forwarded-Email
-
-  # Only required if auth: oidc
-  oidc:
-    client_name: "My Application"
-    scopes:
-      - openid
-      - profile
-      - email
-    redirect_path: /callback
-    consent_mode: implicit
+    # Optional: customize auth headers for forward_auth
+    # Maps Authelia header names to what the app expects
+    # Default: Remote-User, Remote-Groups, Remote-Email, Remote-Name (passed as-is)
+    forward_auth:
+      headers:
+        Remote-User: X-Forwarded-User      # Authelia sends Remote-User, app receives X-Forwarded-User
+        Remote-Groups: X-Forwarded-Groups
+        Remote-Email: X-Forwarded-Email
 ```
 
-If the `traefik` section is omitted:
+If the `routing` section is omitted:
 - Apps with `web_ui.enabled: true` default to Forward Auth
 - Subdomain defaults to `app_id`
+
+**Note**: The deprecated `traefik:` key is no longer supported. Use `routing:` instead.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
- Update SSO_SPEC.md and SSO_ARCHITECTURE.md to use the new `routing:` key instead of the deprecated `traefik:` key
- Add note that `traefik:` is no longer supported

This aligns documentation with container-packaging-tools PR #161.

## Related
- container-packaging-tools#161 - Remove deprecated traefik field from schema

## Test plan
- [x] Documentation renders correctly
- [x] Examples use correct routing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)