### PR TITLE
feat(routing): add HTTP to HTTPS redirect for all routers

### DIFF
--- a/apps/authelia/docker-compose.yml
+++ b/apps/authelia/docker-compose.yml
@@ -13,9 +13,10 @@ services:
       - proxy
     labels:
       - traefik.enable=true
-      # HTTP router
+      # HTTP router (redirects to HTTPS)
       - traefik.http.routers.authelia.rule=Host(`auth.${HALOS_DOMAIN:-halos.local}`)
       - traefik.http.routers.authelia.entrypoints=web
+      - traefik.http.routers.authelia.middlewares=redirect-to-https@file
       # HTTPS router
       - traefik.http.routers.authelia-secure.rule=Host(`auth.${HALOS_DOMAIN:-halos.local}`)
       - traefik.http.routers.authelia-secure.entrypoints=websecure

--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       # HTTP router (redirects to HTTPS)
       - traefik.http.routers.homarr.rule=Host(`${HALOS_DOMAIN}`)
       - traefik.http.routers.homarr.entrypoints=web
+      - traefik.http.routers.homarr.middlewares=redirect-to-https@file
       # HTTPS router
       - traefik.http.routers.homarr-secure.rule=Host(`${HALOS_DOMAIN}`)
       - traefik.http.routers.homarr-secure.entrypoints=websecure

--- a/apps/traefik/assets/dynamic/redirects.yml
+++ b/apps/traefik/assets/dynamic/redirects.yml
@@ -1,0 +1,9 @@
+# HTTP to HTTPS Redirect Middleware
+# Loaded by Traefik's file provider.
+
+http:
+  middlewares:
+    redirect-to-https:
+      redirectScheme:
+        scheme: https
+        permanent: true

--- a/apps/traefik/assets/generate-routing-labels.sh
+++ b/apps/traefik/assets/generate-routing-labels.sh
@@ -189,7 +189,16 @@ generate_override() {
         backend_label="      traefik.http.services.${app_id}.loadbalancer.server.port: \"${port}\""
     fi
 
-    # Generate override file
+    # Build middleware labels for both routers
+    local http_middleware_label=""
+    local https_middleware_label=""
+    if [ -n "${middleware_label}" ]; then
+        # Replace the router name for each entrypoint
+        http_middleware_label="${middleware_label}"
+        https_middleware_label=$(echo "${middleware_label}" | sed "s/routers\.${app_id}\./routers.${app_id}-secure./")
+    fi
+
+    # Generate override file with separate HTTP and HTTPS routers
     local override_file="${OUTPUT_DIR}/${app_id}.yml"
 
     cat > "${override_file}" << EOF
@@ -201,9 +210,16 @@ services:
   ${service_name}:
     labels:
       traefik.enable: "true"
+      # HTTP router - redirects to HTTPS
       traefik.http.routers.${app_id}.rule: "${host_rule}"
-      traefik.http.routers.${app_id}.entrypoints: "web,websecure"
-${middleware_label}
+      traefik.http.routers.${app_id}.entrypoints: "web"
+      traefik.http.routers.${app_id}.middlewares: "redirect-to-https@file"
+      # HTTPS router (websecure entrypoint with TLS)
+      traefik.http.routers.${app_id}-secure.rule: "${host_rule}"
+      traefik.http.routers.${app_id}-secure.entrypoints: "websecure"
+      traefik.http.routers.${app_id}-secure.tls: "true"
+${https_middleware_label}
+      # Backend service
 ${backend_label}
       halos.subdomain: "${subdomain}"
 EOF

--- a/apps/traefik/assets/generate-routing-labels.sh
+++ b/apps/traefik/assets/generate-routing-labels.sh
@@ -189,12 +189,9 @@ generate_override() {
         backend_label="      traefik.http.services.${app_id}.loadbalancer.server.port: \"${port}\""
     fi
 
-    # Build middleware labels for both routers
-    local http_middleware_label=""
+    # Build middleware label for HTTPS router (HTTP router only uses redirect-to-https)
     local https_middleware_label=""
     if [ -n "${middleware_label}" ]; then
-        # Replace the router name for each entrypoint
-        http_middleware_label="${middleware_label}"
         https_middleware_label=$(echo "${middleware_label}" | sed "s/routers\.${app_id}\./routers.${app_id}-secure./")
     fi
 


### PR DESCRIPTION
## Summary
- Add `redirect-to-https` middleware in Traefik dynamic config
- Update `generate-routing-labels.sh` to create separate HTTP and HTTPS routers, with HTTP redirecting to HTTPS
- Add redirect middleware to Homarr and Authelia docker-compose files

This ensures all HTTP requests are automatically redirected to HTTPS, which is required for Authelia ForwardAuth to work correctly.

## Test plan
- [x] Tested on halos.hal device
- [x] Verified all marine apps redirect HTTP to HTTPS (308 Permanent Redirect)
- [x] Verified HTTPS routers work correctly with TLS
- [x] Verified Grafana SSO flow redirects to Authelia

🤖 Generated with [Claude Code](https://claude.com/claude-code)