### PR TITLE
fix(homarr): add auth subdomain to extra_hosts for OIDC

### DIFF
--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -8,8 +8,15 @@ services:
     command: ["sh", "run.sh"]
     extra_hosts:
       - "host.docker.internal:host-gateway"
+      # Allow Homarr to resolve auth subdomain for OIDC (mDNS doesn't work in containers)
+      - "auth.${HALOS_DOMAIN}:host-gateway"
     environment:
       - SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY}
+      # Tell NextAuth the canonical HTTPS URL (behind Traefik proxy)
+      - NEXTAUTH_URL=https://${HALOS_DOMAIN}
+      # SECURITY: Disables TLS verification for ALL Node.js HTTPS requests.
+      # Required for self-signed Traefik certs. Acceptable for local-only device.
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
       # SSO/OIDC configuration (optional, set AUTH_PROVIDERS=oidc to enable)
       - AUTH_PROVIDERS=${AUTH_PROVIDERS:-}
       - AUTH_OIDC_ISSUER=${AUTH_OIDC_ISSUER}


### PR DESCRIPTION
## Summary

- Add `auth.${HALOS_DOMAIN}` to Homarr's `extra_hosts` for container DNS resolution
- Add `NEXTAUTH_URL=https://${HALOS_DOMAIN}` to tell NextAuth the canonical HTTPS URL
- Add `NODE_TLS_REJECT_UNAUTHORIZED=0` for self-signed cert communication

## Problem

OIDC login from Homarr to Authelia was failing due to multiple issues:

1. **Container DNS**: Docker containers cannot resolve mDNS names like `auth.halos.local`
2. **HTTP vs HTTPS**: NextAuth didn't know it was behind an HTTPS proxy, generating `http://` redirect URIs
3. **Self-signed certs**: Node.js rejected Traefik's self-signed certificate

## Solution

1. Add auth subdomain to `extra_hosts` pointing to `host-gateway`
2. Set `NEXTAUTH_URL` to the canonical HTTPS URL
3. Disable TLS verification for internal OIDC communication

## Test plan

- [x] Verified fix on test device (halos.hal)
- [x] Homarr can resolve `auth.halos.local` from within container
- [x] OIDC discovery endpoint accessible
- [x] HTTP to HTTPS redirect works
- [x] OIDC redirect_uri uses HTTPS
- [x] Login flow reaches Authelia login page

## Related Issues

- hatlabs/halos-distro#60 - Device local mDNS resolution (separate issue for /etc/hosts)
- hatlabs/halos-distro#57 - SSO Epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)