### PR TITLE
fix: remove hard-coded hostname references

### DIFF
--- a/apps/authelia/docker-compose.yml
+++ b/apps/authelia/docker-compose.yml
@@ -14,11 +14,12 @@ services:
     labels:
       - traefik.enable=true
       # HTTP router (redirects to HTTPS)
-      - traefik.http.routers.authelia.rule=Host(`auth.${HALOS_DOMAIN:-halos.local}`)
+      # Note: HALOS_DOMAIN must be set by the system environment
+      - traefik.http.routers.authelia.rule=Host(`auth.${HALOS_DOMAIN}`)
       - traefik.http.routers.authelia.entrypoints=web
       - traefik.http.routers.authelia.middlewares=redirect-to-https@file
       # HTTPS router
-      - traefik.http.routers.authelia-secure.rule=Host(`auth.${HALOS_DOMAIN:-halos.local}`)
+      - traefik.http.routers.authelia-secure.rule=Host(`auth.${HALOS_DOMAIN}`)
       - traefik.http.routers.authelia-secure.entrypoints=websecure
       - traefik.http.routers.authelia-secure.tls=true
       - traefik.http.services.authelia.loadbalancer.server.port=9091

--- a/apps/mdns-publisher/metadata.yaml
+++ b/apps/mdns-publisher/metadata.yaml
@@ -6,7 +6,7 @@ description: Advertises HaLOS subdomains via mDNS/Avahi
 long_description: |
   The mDNS Publisher automatically advertises HaLOS application subdomains
   on the local network via Avahi/mDNS. This enables browsers to resolve
-  addresses like auth.halos.local without requiring DNS infrastructure.
+  addresses like auth.<hostname>.local without requiring DNS infrastructure.
 
   The publisher monitors Docker containers for the `halos.subdomain` label
   and dynamically registers/unregisters mDNS records as containers start

--- a/apps/traefik/metadata.yaml
+++ b/apps/traefik/metadata.yaml
@@ -10,7 +10,7 @@ long_description: |
 
   Features:
   - Automatic service discovery from Docker containers
-  - Host-based routing (halos.local, auth.halos.local, etc.)
+  - Host-based routing (subdomains like auth.<hostname>.local)
   - ForwardAuth integration for SSO with Authelia
   - Dynamic configuration updates without restart
   - Built-in dashboard for monitoring (internal only)

--- a/run
+++ b/run
@@ -16,8 +16,6 @@ if [[ $0 != $PROJECT_ROOT && $PROJECT_ROOT != "" ]]; then
 fi
 readonly PROJECT_ROOT=$(pwd)
 
-# Default deploy target
-readonly DEFAULT_DEPLOY_TARGET="halos.local"
 
 # Docker image name for building
 readonly DOCKER_IMAGE="halos-core-containers-builder"
@@ -52,10 +50,23 @@ function build {
 # Deploy Commands
 
 function deploy {
-  #@ Deploy packages to test server (default: all packages to halos.local)
+  #@ Deploy packages to test server (usage: ./run deploy <target> [packages])
   #@ Category: Deploy
-  local target="${1:-$DEFAULT_DEPLOY_TARGET}"
+  local target="${1:-}"
   local packages="${2:-all}"
+
+  if [[ -z "$target" ]]; then
+    echo "Usage: ./run deploy <target> [packages]"
+    echo ""
+    echo "Arguments:"
+    echo "  target     Target host (e.g., pi@myhost.local)"
+    echo "  packages   Package names or 'all' (default: all)"
+    echo ""
+    echo "Examples:"
+    echo "  ./run deploy pi@myhost.local"
+    echo "  ./run deploy pi@myhost.local homarr"
+    return 1
+  fi
   local deb_files=()
 
   if [ "$packages" = "all" ]; then
@@ -151,9 +162,9 @@ function help {
   echo "Usage: ./run <command> [target_host]"
   echo ""
   echo "Quick start:"
-  echo "  1. ./run build-debtools  # Build packaging container (first time)"
-  echo "  2. ./run build           # Build all container packages"
-  echo "  3. ./run deploy          # Deploy homarr-container to halos.local"
+  echo "  1. ./run build-debtools             # Build packaging container (first time)"
+  echo "  2. ./run build                      # Build all container packages"
+  echo "  3. ./run deploy pi@myhost.local     # Deploy container packages to test server"
 }
 
 ################################################################################


### PR DESCRIPTION
## Summary
- Remove `HALOS_DOMAIN` fallback from authelia docker-compose.yml
  (HALOS_DOMAIN must be set by system environment)
- Update metadata.yaml descriptions to use generic hostname patterns
- Remove `DEFAULT_DEPLOY_TARGET` from run script  
- Update `deploy` function to require explicit target parameter

## Notes
For docker-compose.yml, the `HALOS_DOMAIN` environment variable must now be set
by the system rather than relying on a fallback. This ensures consistent configuration
across all HaLOS installations.

## Test plan
- [ ] Verify lint check passes (after infrastructure PR is merged)
- [ ] Verify deploy function shows usage when target is not provided
- [ ] Verify authelia container starts correctly when HALOS_DOMAIN is set

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)