### PR TITLE
fix(ci): add HALOS_HOSTNAME env var for package builds

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -27,4 +27,8 @@ runs:
 
     - name: Build packages
       shell: bash
+      env:
+        # Placeholder hostname for registry URL generation during build.
+        # The actual URL is determined at runtime by homarr-container-adapter.
+        HALOS_HOSTNAME: halos.local
       run: ./tools/build-all.sh


### PR DESCRIPTION
## Summary

Container-packaging-tools now requires `HALOS_HOSTNAME` for registry URL generation. Set a placeholder value that will be replaced at runtime by homarr-container-adapter.

## Changes

- Added `HALOS_HOSTNAME: halos.local` env var to build action

## Related

Fixes the CI failure from PR #53/#54 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)