### PR TITLE
fix(ci): use RFC 2606 placeholder instead of halos.local

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -28,7 +28,8 @@ runs:
     - name: Build packages
       shell: bash
       env:
-        # Placeholder hostname for registry URL generation during build.
+        # Build-time placeholder for registry URL generation.
+        # Uses RFC 2606 reserved domain to clearly indicate this is not a real hostname.
         # The actual URL is determined at runtime by homarr-container-adapter.
-        HALOS_HOSTNAME: halos.local
+        HALOS_HOSTNAME: build.example.local
       run: ./tools/build-all.sh


### PR DESCRIPTION
## Summary

Addresses review comment on PR #88 regarding hostname policy violation.

Replace `halos.local` with `build.example.local` to comply with the hostname policy documented in `halos-distro/docs/HOSTNAME_POLICY.md`.

## Changes

- Changed `HALOS_HOSTNAME` from `halos.local` to `build.example.local`
- Updated comment to explain RFC 2606 reserved domain usage

## Rationale

The `example.local` domain is RFC 2606 reserved for documentation and testing purposes. Using `build.example.local`:

1. **Clearly indicates this is a placeholder** - not a real hostname
2. **Doesn't match the lint check pattern** - `halos.(local|hal)`
3. **Follows RFC standards** - proper use of reserved domains

The actual URL is determined at runtime by homarr-container-adapter, so the build-time value is purely a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)