### PR TITLE
fix(traefik): use HTTPS for Cockpit backend connection

### DIFF
--- a/apps/traefik/prestart.sh
+++ b/apps/traefik/prestart.sh
@@ -136,8 +136,13 @@ http:
   services:
     cockpit:
       loadBalancer:
+        serversTransport: cockpit-transport
         servers:
-          - url: "http://host.docker.internal:9090"
+          - url: "https://host.docker.internal:9090"
+
+  serversTransports:
+    cockpit-transport:
+      insecureSkipVerify: true
 EOF
 
 chmod 644 "${COCKPIT_CONFIG_FILE}"


### PR DESCRIPTION
## Summary

Fix ERR_TOO_MANY_REDIRECTS when accessing Cockpit via Traefik.

## Problem

Cockpit uses HTTPS with a self-signed certificate on port 9090. The routing configuration was sending HTTP to Cockpit, which redirected to HTTPS, causing an infinite redirect loop.

## Solution

- Use `https://` URL for the Cockpit backend
- Add `serversTransport` with `insecureSkipVerify: true` to accept Cockpit's self-signed certificate

## Test plan

- [ ] Access https://cockpit.halos.local/
- [ ] Verify no redirect loop
- [ ] Verify Cockpit UI loads and login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)