### PR TITLE
fix(traefik): add insecure transport for HTTPS backends, remove HALOS_HOSTNAME

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -27,9 +27,4 @@ runs:
 
     - name: Build packages
       shell: bash
-      env:
-        # Build-time placeholder for registry URL generation.
-        # Uses RFC 2606 reserved domain to clearly indicate this is not a real hostname.
-        # The actual URL is determined at runtime by homarr-container-adapter.
-        HALOS_HOSTNAME: build.example.local
       run: ./tools/build-all.sh

--- a/apps/traefik/assets/dynamic/insecure-transport.yml
+++ b/apps/traefik/assets/dynamic/insecure-transport.yml
@@ -1,0 +1,11 @@
+# ServersTransport for backends with self-signed certificates
+# Used when routing.backend.scheme is "https"
+#
+# This transport skips TLS certificate verification, which is necessary
+# for backends that use self-signed certificates (e.g., OpenCPN with
+# selkies-gstreamer).
+
+http:
+  serversTransports:
+    insecure:
+      insecureSkipVerify: true

--- a/apps/traefik/assets/generate-routing-labels.sh
+++ b/apps/traefik/assets/generate-routing-labels.sh
@@ -187,13 +187,16 @@ generate_override() {
     local scheme="${backend_scheme:-http}"
     local backend_label
     local scheme_label=""
+    local transport_label=""
     if [ "${backend_type}" = "host" ]; then
         backend_label="      traefik.http.services.${app_id}.loadbalancer.server.url: \"${scheme}://host.docker.internal:${port}\""
     else
         backend_label="      traefik.http.services.${app_id}.loadbalancer.server.port: \"${port}\""
-        # Add scheme label for HTTPS backends (Traefik defaults to HTTP)
+        # Add scheme and transport labels for HTTPS backends
+        # Traefik defaults to HTTP, and HTTPS backends typically use self-signed certs
         if [ "${scheme}" = "https" ]; then
             scheme_label="      traefik.http.services.${app_id}.loadbalancer.server.scheme: \"https\""
+            transport_label="      traefik.http.services.${app_id}.loadbalancer.serversTransport: \"insecure@file\""
         fi
     fi
 
@@ -227,6 +230,7 @@ ${https_middleware_label}
       # Backend service
 ${backend_label}
 ${scheme_label}
+${transport_label}
       halos.subdomain: "${subdomain}"
 EOF
 

--- a/run
+++ b/run
@@ -42,7 +42,17 @@ function build {
   fi
 
   # Run build in Docker container
-  docker run --rm -v "$(pwd):/workspace" "$DOCKER_IMAGE" \
+  # CONTAINER_TOOLS_REF can specify a git ref for container-packaging-tools
+  # CONTAINER_TOOLS_PATH can specify a local path to mount (for development)
+  local mount_opts="-v $(pwd):/workspace"
+  if [[ -n "${CONTAINER_TOOLS_PATH:-}" ]]; then
+    mount_opts="$mount_opts -v $CONTAINER_TOOLS_PATH:/container-tools"
+  fi
+
+  docker run --rm $mount_opts \
+    -e CONTAINER_TOOLS_REF="${CONTAINER_TOOLS_REF:-}" \
+    -e CONTAINER_TOOLS_PATH="${CONTAINER_TOOLS_PATH:+/container-tools}" \
+    "$DOCKER_IMAGE" \
     bash -c "cd /workspace && ./tools/build-all.sh"
 }
 

--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -19,11 +19,26 @@ mkdir -p "$BUILD_DIR"
 if command -v uvx >/dev/null 2>&1; then
     echo ""
     echo "=== Building container app packages ==="
+
+    # Determine tools source: local path, git ref, or default
+    TOOLS_PATH="${CONTAINER_TOOLS_PATH:-}"
+    TOOLS_REF="${CONTAINER_TOOLS_REF:-}"
+    if [ -n "$TOOLS_PATH" ]; then
+        TOOLS_SOURCE="$TOOLS_PATH"
+        echo "Using local container-packaging-tools from: $TOOLS_PATH"
+    elif [ -n "$TOOLS_REF" ]; then
+        TOOLS_SOURCE="git+https://github.com/hatlabs/container-packaging-tools.git@${TOOLS_REF}"
+        echo "Using container-packaging-tools ref: $TOOLS_REF"
+    else
+        TOOLS_SOURCE="git+https://github.com/hatlabs/container-packaging-tools.git"
+        echo "Using container-packaging-tools from main branch"
+    fi
+
     for app_dir in "${REPO_ROOT}/apps"/*; do
         if [ -d "$app_dir" ]; then
             app_name=$(basename "$app_dir")
             echo "Building package for: $app_name"
-            if ! uvx --from git+https://github.com/hatlabs/container-packaging-tools.git \
+            if ! uvx --from "$TOOLS_SOURCE" \
                      generate-container-packages -o "$BUILD_DIR" --prefix halos "$app_dir"; then
                 echo "ERROR: Failed to build package for $app_name" >&2
                 exit 1


### PR DESCRIPTION
## Summary

Two related fixes:

### 1. Insecure transport for HTTPS backends
When `routing.backend.scheme` is `https`, Traefik needs to skip TLS certificate verification for backends with self-signed certificates (e.g., OpenCPN with selkies-gstreamer).

- Add `insecure-transport.yml` to dynamic config with `insecureSkipVerify: true`
- Update `generate-routing-labels.sh` to add `serversTransport` label for HTTPS backends
- Update `prestart.sh` to install all dynamic config files from package

### 2. Remove HALOS_HOSTNAME placeholder
- Remove bogus `HALOS_HOSTNAME=build.example.local` from CI
- Add `CONTAINER_TOOLS_PATH` support for local development builds

This is a companion PR to:
- hatlabs/container-packaging-tools#174 (template variables for URLs)
- hatlabs/halos-marine-containers#94 (remove placeholder)

## Test plan

- [x] Built and deployed to test device
- [x] Verified `insecure-transport.yml` is installed by package
- [x] Verified OpenCPN routing labels include `serversTransport: "insecure@file"`
- [x] Verified `https://opencpn.halos.local/` returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)