### PR TITLE
fix(authelia): override healthcheck for faster Traefik routing

### DIFF
--- a/apps/authelia/docker-compose.yml
+++ b/apps/authelia/docker-compose.yml
@@ -9,6 +9,13 @@ services:
       - TZ=${TZ:-UTC}
       # Load base configuration and OIDC clients (merged by Authelia)
       - X_AUTHELIA_CONFIG=/config/configuration.yml,/config/oidc-clients.yml
+    # Override image's 60s start_period - Traefik won't route until healthy
+    healthcheck:
+      test: ["CMD-SHELL", "/app/healthcheck.sh"]
+      interval: 2s
+      timeout: 3s
+      start_period: 1s
+      retries: 3
     networks:
       - proxy
     labels:

--- a/apps/authelia/metadata.yaml
+++ b/apps/authelia/metadata.yaml
@@ -1,6 +1,6 @@
 name: Authelia
 app_id: authelia
-version: 4.39.15-1
+version: 4.39.15-2
 upstream_version: 4.39.15
 description: Identity provider for HaLOS Single Sign-On
 long_description: |


### PR DESCRIPTION
## Summary

- Override Authelia image's 60-second healthcheck start_period with 1s
- Reduces routing availability delay from 24+ seconds to ~3 seconds after reboot

## Problem

Traefik v3 won't route to containers until their Docker healthcheck status is "healthy". Authelia's Docker image has a 60-second `start_period` in its healthcheck definition, causing the container to remain in "starting" state for up to a minute after startup.

This resulted in 404 errors when accessing auth.halos.local immediately after system reboot, because Homarr redirects to Authelia for OIDC authentication before Authelia is ready.

## Solution

Override the image's healthcheck in docker-compose.yml with:
- `start_period: 1s` (down from 60s)
- `interval: 2s` (more frequent checks)
- `retries: 3` (reasonable retry count)

## Test plan

- [x] Reboot test device
- [x] Verify auth.halos.local responds within 5 seconds of Traefik starting
- [x] Verify Authelia healthcheck transitions from "starting" to "healthy" quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)