### PR TITLE
fix: add missing release.yml for stable channel dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release Published
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
+    with:
+      apt-distro: trixie
+      apt-component: main
+    secrets:
+      APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}


### PR DESCRIPTION
## Summary

- Adds missing `release.yml` workflow that dispatches to apt.hatlabs.fi stable channel when releases are published
- Fixes halos-pi-gen build failures due to missing packages in stable channel

## Root Cause

The `build-release.yml` workflow creates pre-releases and draft releases, but only dispatches to the **unstable** channel. The `release.yml` workflow is needed to dispatch to the **stable** channel when the draft release is published.

Without this workflow, packages were only available in `apt.hatlabs.fi` unstable channel, causing halos-pi-gen builds to fail with:

```
halos : Depends: halos-homarr-container but it is not installable
```

## Test plan

- [ ] Merge this PR
- [ ] Verify the existing v0.2.1+4 release triggers the new workflow
- [ ] Or manually trigger apt.hatlabs.fi rebuild if needed
- [ ] Verify halos-pi-gen build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)