### PR TITLE
fix(traefik): wait for Authelia before starting to prevent HTTP 500

### DIFF
--- a/apps/traefik/assets/wait-for-authelia.sh
+++ b/apps/traefik/assets/wait-for-authelia.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Wait for Authelia to be ready before starting Traefik
+# This prevents HTTP 500 errors during boot when forward-auth
+# middleware tries to reach Authelia before it's healthy.
+
+set -e
+
+AUTHELIA_URL="${AUTHELIA_HEALTH_URL:-http://authelia:9091/api/health}"
+MAX_WAIT="${AUTHELIA_WAIT_TIMEOUT:-60}"
+WAIT_INTERVAL=1
+ELAPSED=0
+
+echo "Waiting for Authelia to be ready at ${AUTHELIA_URL}..."
+
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+    if wget -q -O /dev/null --timeout=2 "${AUTHELIA_URL}" 2>/dev/null; then
+        echo "Authelia is ready (waited ${ELAPSED}s)"
+        break
+    fi
+
+    # Show status every 5 seconds
+    if [ $((ELAPSED % 5)) -eq 0 ] && [ $ELAPSED -gt 0 ]; then
+        echo "  Still waiting for Authelia... (${ELAPSED}s)"
+    fi
+
+    sleep $WAIT_INTERVAL
+    ELAPSED=$((ELAPSED + WAIT_INTERVAL))
+done
+
+if [ $ELAPSED -ge $MAX_WAIT ]; then
+    echo "WARNING: Authelia not ready after ${MAX_WAIT}s"
+    echo "Starting Traefik anyway - forward-auth may return 500 until Authelia is ready"
+fi
+
+# Execute the original Traefik entrypoint
+exec /entrypoint.sh "$@"

--- a/apps/traefik/docker-compose.yml
+++ b/apps/traefik/docker-compose.yml
@@ -3,12 +3,16 @@ services:
     image: traefik:v3.6
     container_name: traefik
     restart: unless-stopped
+    # Wait for Authelia before starting Traefik to avoid HTTP 500 during boot
+    entrypoint: ["/wait-for-authelia.sh"]
+    command: ["traefik"]
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./assets/wait-for-authelia.sh:/wait-for-authelia.sh:ro
       # Dynamic middleware directory - apps drop their files here
       - /etc/halos/traefik-dynamic.d:/etc/traefik/dynamic:ro
       # Generic routing declarations - read by prestart to generate labels

--- a/apps/traefik/metadata.yaml
+++ b/apps/traefik/metadata.yaml
@@ -1,6 +1,6 @@
 name: Traefik
 app_id: traefik
-version: 3.6.5-3
+version: 3.6.5-4
 upstream_version: 3.6.5
 description: Reverse proxy and load balancer for HaLOS
 long_description: |


### PR DESCRIPTION
## Summary

- Adds a custom entrypoint script (`wait-for-authelia.sh`) that waits for Authelia's health endpoint before starting Traefik
- Eliminates the ~7 second HTTP 500 window during boot when Traefik's forward-auth middleware tries to reach Authelia before it's healthy
- Uses network-based health checking within Docker network (no Docker socket access from host)

## Problem

On fresh boot, Traefik would start before Authelia was healthy, causing forward-auth middleware to return HTTP 500. Users would see errors on halos.local for several seconds after boot.

## Solution

The wait-for-authelia.sh script:
1. Polls Authelia's health endpoint at `http://authelia:9091/api/health`
2. Waits up to 60 seconds (configurable via `AUTHELIA_WAIT_TIMEOUT`)
3. Once healthy, executes Traefik's original entrypoint

## Test Plan

- [x] Deploy to test device and reset data directories
- [x] Reboot and poll HTTP continuously during boot
- [x] Verify no HTTP 500 responses during boot window
- [x] Confirmed: HTTP 302 (auth redirect) returned immediately when device ready

## Test Results

```
Waiting for Authelia to be ready at http://authelia:9091/api/health...
  Still waiting for Authelia... (5s)
  Still waiting for Authelia... (10s)
Authelia is ready (waited 14s)
```

Boot poll showed 0 HTTP 500 errors - straight from "no response" during reboot to HTTP 302 (working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)