### PR TITLE
fix(traefik): rebuild with fixed assets installation path

### DIFF
--- a/apps/traefik/metadata.yaml
+++ b/apps/traefik/metadata.yaml
@@ -1,6 +1,6 @@
 name: Traefik
 app_id: traefik
-version: 3.6.5-4
+version: 3.6.5-5
 upstream_version: 3.6.5
 description: Reverse proxy and load balancer for HaLOS
 long_description: |


### PR DESCRIPTION
## Summary

- Bumps traefik version to trigger rebuild with fixed container-packaging-tools
- Fixes issue where `wait-for-authelia.sh` was installed to wrong location

## Related

- Depends on: hatlabs/container-packaging-tools#181 (merged)

## Root Cause

The container-packaging-tools template installed assets directly to the lib directory instead of preserving the `assets/` subdirectory. This caused docker-compose.yml's `./assets/wait-for-authelia.sh` mount to create an empty directory instead of finding the file.

## Test plan

- [ ] CI builds successfully
- [ ] Deploy to test device
- [ ] Verify Traefik starts without errors
- [ ] Verify `wait-for-authelia.sh` is at `/var/lib/container-apps/halos-traefik-container/assets/wait-for-authelia.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)