### PR TITLE
fix(traefik): correct traefik.yml path to assets/ directory

### DIFF
--- a/apps/authelia/metadata.yaml
+++ b/apps/authelia/metadata.yaml
@@ -1,6 +1,6 @@
 name: Authelia
 app_id: authelia
-version: 4.39.15-4
+version: 4.39.15-5
 upstream_version: 4.39.15
 description: Identity provider for HaLOS Single Sign-On
 long_description: |

--- a/apps/authelia/prestart.sh
+++ b/apps/authelia/prestart.sh
@@ -17,7 +17,7 @@ set +a
 
 # CONTAINER_DATA_ROOT already points to the data directory
 DATA_DIR="${CONTAINER_DATA_ROOT}"
-TEMPLATE_FILE="${SCRIPT_DIR}/configuration.yml.template"
+TEMPLATE_FILE="${SCRIPT_DIR}/assets/configuration.yml.template"
 SECRETS_FILE="${DATA_DIR}/secrets.env"
 CONFIG_FILE="${DATA_DIR}/configuration.yml"
 OIDC_CLIENTS_FILE="${DATA_DIR}/oidc-clients.yml"

--- a/apps/homarr/docker-compose.yml
+++ b/apps/homarr/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ${CONTAINER_DATA_ROOT}/data:/appdata
       # Custom entrypoint that patches nginx to serve local assets
-      - ./custom-entrypoint.sh:/custom-entrypoint.sh:ro
+      - ./assets/custom-entrypoint.sh:/custom-entrypoint.sh:ro
       # Asset volumes (served via patched nginx)
       - /usr/share/pixmaps:/usr/share/pixmaps:ro
       - /usr/share/halos-homarr-branding:/usr/share/halos-homarr-branding:ro

--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,6 +1,6 @@
 name: Homarr
 app_id: homarr
-version: 1.45.3-11
+version: 1.45.3-12
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
 long_description: |

--- a/apps/homarr/metadata.yaml
+++ b/apps/homarr/metadata.yaml
@@ -1,6 +1,6 @@
 name: Homarr
 app_id: homarr
-version: 1.45.3-10
+version: 1.45.3-11
 upstream_version: 1.45.3
 description: Dashboard landing page for HaLOS
 long_description: |

--- a/apps/homarr/prestart.sh
+++ b/apps/homarr/prestart.sh
@@ -15,7 +15,7 @@ DATA_DIR="/var/lib/container-apps/${PACKAGE_NAME}/data"
 # OIDC client configuration
 OIDC_CLIENTS_DIR="/etc/halos/oidc-clients.d"
 OIDC_SECRET_FILE="${DATA_DIR}/oidc-secret"
-OIDC_SNIPPET_SRC="${SCRIPT_DIR}/oidc-client.yml"
+OIDC_SNIPPET_SRC="${SCRIPT_DIR}/assets/oidc-client.yml"
 OIDC_SNIPPET_DST="${OIDC_CLIENTS_DIR}/homarr.yml"
 
 # Seed database from halos-homarr-branding

--- a/apps/traefik/docker-compose.yml
+++ b/apps/traefik/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./assets/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./assets/wait-for-authelia.sh:/wait-for-authelia.sh:ro
       # Dynamic middleware directory - apps drop their files here
       - /etc/halos/traefik-dynamic.d:/etc/traefik/dynamic:ro

--- a/apps/traefik/metadata.yaml
+++ b/apps/traefik/metadata.yaml
@@ -1,6 +1,6 @@
 name: Traefik
 app_id: traefik
-version: 3.6.5-5
+version: 3.6.5-6
 upstream_version: 3.6.5
 description: Reverse proxy and load balancer for HaLOS
 long_description: |

--- a/apps/traefik/metadata.yaml
+++ b/apps/traefik/metadata.yaml
@@ -1,6 +1,6 @@
 name: Traefik
 app_id: traefik
-version: 3.6.5-6
+version: 3.6.5-7
 upstream_version: 3.6.5
 description: Reverse proxy and load balancer for HaLOS
 long_description: |

--- a/apps/traefik/prestart.sh
+++ b/apps/traefik/prestart.sh
@@ -159,7 +159,7 @@ echo "Cockpit routing configuration written to ${COCKPIT_CONFIG_FILE}"
 # This directory allows per-app middleware configurations
 # Apps can drop their own middleware files here
 DYNAMIC_DIR="/etc/halos/traefik-dynamic.d"
-DYNAMIC_SRC_DIR="${SCRIPT_DIR}/dynamic"
+DYNAMIC_SRC_DIR="${SCRIPT_DIR}/assets/dynamic"
 mkdir -p "${DYNAMIC_DIR}"
 
 # Install all dynamic config files from package


### PR DESCRIPTION
## Summary

Updates all core container apps to reference assets from the `assets/` subdirectory, matching the container-packaging-tools fix (hatlabs/container-packaging-tools#181) that preserves the source directory structure.

**Changes:**
- **traefik**: 
  - `./traefik.yml` → `./assets/traefik.yml` in docker-compose.yml
  - `DYNAMIC_SRC_DIR` → `assets/dynamic` in prestart.sh
- **homarr**: 
  - `./custom-entrypoint.sh` → `./assets/custom-entrypoint.sh` in docker-compose.yml
  - `OIDC_SNIPPET_SRC` → `assets/oidc-client.yml` in prestart.sh
- **authelia**: 
  - `configuration.yml.template` → `assets/configuration.yml.template` in prestart.sh

## Root Cause

The container-packaging-tools now correctly installs assets to the `assets/` subdirectory (reducing clutter in the top-level directory). All references to these assets needed to be updated.

## Test plan

- [x] Built packages locally
- [x] Deployed to test device
- [x] Verified all three services start successfully
- [x] Verified HTTPS works (302 redirect to Authelia)
- [x] Verified assets are in correct locations
- [x] Verified dynamic configs installed to /etc/halos/traefik-dynamic.d/
- [x] Verified OIDC client installed to /etc/halos/oidc-clients.d/

🤖 Generated with [Claude Code](https://claude.com/claude-code)