### PR TITLE
fix(build): preserve CI-generated changelog with correct revision

### DIFF
--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -21,9 +21,13 @@ fi
 VERSION=$(cat VERSION)
 echo "Package version: $VERSION"
 
-# Generate changelog
-echo "Generating debian/changelog..."
-.github/scripts/generate-changelog.sh --upstream "$VERSION" --revision 1
+# Generate changelog only if not already present (CI generates it with correct revision)
+if [ ! -f debian/changelog ]; then
+    echo "Generating debian/changelog..."
+    .github/scripts/generate-changelog.sh --upstream "$VERSION" --revision 1
+else
+    echo "Using existing debian/changelog"
+fi
 
 # Clean build directory
 rm -rf "$BUILD_DIR"


### PR DESCRIPTION
## Summary

- Fix version mismatch where packages were built with `0.2.1-1` instead of `0.2.1-13`
- The build script was overwriting the CI-generated changelog that had the correct revision
- Now preserves existing changelog (from CI) while still supporting local builds

## Root Cause

The `build-all.sh` script unconditionally called `generate-changelog.sh --revision 1`, overwriting the changelog that the CI workflow (`build-release.yml`) had already generated with the correct revision number calculated from git tags.

## Test plan

- [ ] Verify CI builds package with correct version matching the release tag
- [ ] Verify local builds still work (generate changelog with revision 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)