### PR TITLE
Update container versions to latest releases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: traefik:v3.6
+    image: traefik:v3.6.6
     container_name: traefik
     restart: unless-stopped
     depends_on:
@@ -30,7 +30,7 @@ services:
         tag: "{{.Name}}"
 
   authelia:
-    image: authelia/authelia:4.39
+    image: authelia/authelia:4.39.15
     container_name: authelia
     restart: unless-stopped
     volumes:
@@ -66,8 +66,7 @@ services:
         tag: "{{.Name}}"
 
   homarr:
-    # Using hatlabs fork until homarr-labs/homarr#4372 is merged
-    image: ghcr.io/hatlabs/homarr:api-key-test
+    image: ghcr.io/homarr-labs/homarr:v1.50.0
     container_name: homarr
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Summary
- Update Traefik from v3.6 to v3.6.6 (includes security fixes for CVE-2025-66490/66491)
- Update Authelia from 4.39 to 4.39.15
- Switch Homarr from hatlabs fork to official homarr-labs/homarr:v1.50.0 (blocking PR homarr-labs/homarr#4372 was merged in October 2025)

## Test plan
- [ ] Deploy to test device and verify all three containers start successfully
- [ ] Verify Traefik routing works (access Homarr via HTTPS)
- [ ] Verify Authelia authentication flow
- [ ] Verify Homarr dashboard loads and displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)