### PR TITLE
Prioritize docker.io over docker-ce in dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/hatlabs/halos-core-containers
 
 Package: halos-core-containers
 Architecture: all
-Depends: ${misc:Depends}, docker-compose | docker-compose-plugin, docker-ce (>= 20.10) | docker.io (>= 20.10), halos-homarr-branding
+Depends: ${misc:Depends}, docker-compose | docker-compose-plugin, docker.io (>= 20.10) | docker-ce (>= 20.10), halos-homarr-branding
 Recommends: halos-cockpit-config
 Provides: halos-reverse-proxy
 Conflicts: halos-reverse-proxy

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,8 @@ debian_section: web
 architecture: all
 
 depends:
-  - docker-ce (>= 20.10) | docker.io (>= 20.10)
+  - docker.io (>= 20.10) | docker-ce (>= 20.10)
+  - docker-compose | docker-compose-plugin
   - halos-homarr-branding
 
 recommends:


### PR DESCRIPTION
## Summary
- Change dependency order from `docker-ce | docker.io` to `docker.io | docker-ce`
- Updates both debian/control and metadata.yaml

Part of docker.io migration: hatlabs/halos-pi-gen#22

## Test plan
- [x] Package builds successfully
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)