### PR TITLE
fix(authelia): increase default session lifetime to 1 year

### DIFF
--- a/assets/authelia/configuration.yml.template
+++ b/assets/authelia/configuration.yml.template
@@ -25,6 +25,10 @@ authentication_backend:
 
 session:
   secret: '${SESSION_SECRET}'
+  # Long session lifetimes for environments with intermittent use (e.g., boats)
+  expiration: 8760h      # 1 year
+  inactivity: 8760h      # 1 year (effectively disables idle timeout)
+  remember_me: 8760h     # 1 year
   cookies:
     - domain: '${HALOS_DOMAIN}'
       authelia_url: 'https://auth.${HALOS_DOMAIN}'


### PR DESCRIPTION
## Summary

- Set session `expiration` to 1 year (8760h)
- Set session `inactivity` to 1 year (effectively disables idle timeout)
- Set session `remember_me` to 1 year

## Motivation

HaLOS is typically used in environments where frequent re-authentication is undesirable (e.g., boats where the device is used intermittently). The Authelia defaults (1 hour expiration, 5 minute inactivity) are too aggressive for this use case.

## Limitations

This change alone doesn't make sessions survive Authelia restarts - that requires external session storage (tracked separately). However, longer session lifetimes reduce the frequency of re-authentication when restarts don't occur.

## Test plan

- [x] Verify YAML syntax is valid
- [ ] Deploy to test device and verify sessions persist for extended periods

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)