### PR TITLE
Update Traefik to 3.6.7, Homarr to 1.51.0, Valkey to 9.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   traefik:
-    image: traefik:v3.6.6
+    image: traefik:v3.6.7
     container_name: traefik
     restart: unless-stopped
     depends_on:
@@ -70,7 +70,7 @@ services:
         tag: "{{.Name}}"
 
   authelia-valkey:
-    image: valkey/valkey:8.1.5-alpine
+    image: valkey/valkey:9.0.1-alpine
     container_name: authelia-valkey
     restart: unless-stopped
     volumes:
@@ -94,7 +94,7 @@ services:
         tag: "{{.Name}}"
 
   homarr:
-    image: ghcr.io/homarr-labs/homarr:v1.50.0
+    image: ghcr.io/homarr-labs/homarr:v1.51.0
     container_name: homarr
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Summary

- Update Traefik from v3.6.6 to v3.6.7 (patch)
- Update Homarr from v1.50.0 to v1.51.0 (minor)
- Update Valkey from 8.1.5 to 9.0.1 (major)

## Test plan

- [ ] Verify CI builds successfully
- [ ] Deploy on test device and verify all core services start
- [ ] Verify Traefik routing, Authelia SSO, and Homarr dashboard work
- [ ] Verify Valkey health check passes (Authelia depends on it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)