### PR TITLE
Document version bump CI requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Individual apps in `apps/` have their own versions in `metadata.yaml`. These are
 - Stable: `v{VERSION}+{N}` (stable channel)
 - N = auto-calculated from existing git tags
 
+**CI Enforcement**: PRs that change app files in `apps/<app>/` must include a bump to the `version` field in `apps/<app>/metadata.yaml`, or CI will fail. Changes outside `apps/` that affect the package also require a VERSION file bump.
+
 ## What This Repository Contains
 
 **Container app definitions only** - no store package:


### PR DESCRIPTION
## Summary
- Add CI enforcement note to Version Management section documenting that PRs changing app files require metadata.yaml version bumps and other package-affecting changes require VERSION bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)