### PR TITLE
Set NO_EXTERNAL_CONNECTION=true for Homarr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,8 @@ services:
       - AUTH_LOGOUT_REDIRECT_URL=${AUTH_LOGOUT_REDIRECT_URL}
       # Auto-redirect to OIDC provider on login page for seamless SSO
       - AUTH_OIDC_AUTO_LOGIN=true
+      # Suppress external network requests (icon updates, analytics, update checks)
+      - NO_EXTERNAL_CONNECTION=true
     ports:
       # Expose to localhost only for homarr-container-adapter
       - "127.0.0.1:7575:7575"


### PR DESCRIPTION
## Summary

- Add `NO_EXTERNAL_CONNECTION=true` to Homarr's environment in docker-compose.yml

When set, Homarr's server-side cron jobs exit immediately:
- **Icons updater** (weekly + startup) — fetches icon repo indexes from GitHub API + jsDelivr
- **Analytics submission** (weekly + startup) — sends to `umami.homarr.dev`
- **Update checker** (hourly) — queries GitHub API via Octokit

## Test plan

- [ ] Verify Homarr starts normally with the env var set
- [ ] Check container logs on startup for absence of external fetch errors

Closes hatlabs/halos-distro#81

🤖 Generated with [Claude Code](https://claude.com/claude-code)