### PR TITLE
feat: add scheduled container image update checks

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -1,0 +1,19 @@
+name: Check Container Image Updates
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.repository }}-check-image-updates
+  cancel-in-progress: true
+
+jobs:
+  check-updates:
+    uses: hatlabs/shared-workflows/.github/workflows/check-image-updates.yml@main
+    with:
+      compose-pattern: docker-compose.yml
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Adds daily scheduled workflow (06:00 UTC) that calls the shared `check-image-updates` reusable workflow to detect outdated images in `docker-compose.yml`
- Also triggerable manually via `workflow_dispatch`
- Concurrency group prevents parallel runs

Depends on hatlabs/shared-workflows#13 being merged first.

## Test plan

- [ ] Merge the shared-workflows PR first
- [ ] Trigger this workflow manually via Actions tab
- [ ] Verify correct image detection and PR creation
- [ ] Optionally configure a PAT/App token secret named `token` to enable CI triggers on auto-created PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)