### PR TITLE
chore: migrate org references from hatlabs to halos-org

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -90,8 +90,8 @@ sudo apt install halos-homarr-container halos-traefik-container halos-authelia-c
 ### Development
 
 For development setup and build commands, see:
-- [README.md](https://github.com/hatlabs/halos-core-containers/blob/main/README.md) - Installation and usage
-- [AGENTS.md](https://github.com/hatlabs/halos-core-containers/blob/main/AGENTS.md) - Development guide
+- [README.md](https://github.com/halos-org/halos-core-containers/blob/main/README.md) - Installation and usage
+- [AGENTS.md](https://github.com/halos-org/halos-core-containers/blob/main/AGENTS.md) - Development guide
 EOF
     ;;
 
@@ -123,8 +123,8 @@ sudo apt install halos-homarr-container halos-traefik-container halos-authelia-c
 ### Development
 
 For development setup and build commands, see:
-- [README.md](https://github.com/hatlabs/halos-core-containers/blob/main/README.md) - Installation and usage
-- [AGENTS.md](https://github.com/hatlabs/halos-core-containers/blob/main/AGENTS.md) - Development guide
+- [README.md](https://github.com/halos-org/halos-core-containers/blob/main/README.md) - Installation and usage
+- [AGENTS.md](https://github.com/halos-org/halos-core-containers/blob/main/AGENTS.md) - Development guide
 EOF
     ;;
 

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   check-updates:
-    uses: hatlabs/shared-workflows/.github/workflows/check-image-updates.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/check-image-updates.yml@main
     with:
       compose-pattern: docker-compose.yml
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.repository }}-main-release
   cancel-in-progress: false
 
+permissions:
+  contents: write
+
 jobs:
   build-release:
     uses: halos-org/shared-workflows/.github/workflows/build-release.yml@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build-release:
-    uses: hatlabs/shared-workflows/.github/workflows/build-release.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/build-release.yml@main
     with:
       package-name: homarr-container
       package-description: 'Homarr dashboard container for HaLOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     uses: halos-org/shared-workflows/.github/workflows/publish-stable.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
+    uses: halos-org/shared-workflows/.github/workflows/publish-stable.yml@main
     with:
       apt-distro: trixie
       apt-component: main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repository should be used as part of the halos-distro workspace for AI-assi
 
 ```bash
 # Clone workspace and all repos
-git clone https://github.com/hatlabs/halos-distro.git
+git clone https://github.com/halos-org/halos-distro.git
 cd halos-distro
 ./run repos:clone
 ```
@@ -107,5 +107,5 @@ halos-core-containers/
 ## Related
 
 - **Parent**: [../AGENTS.md](../AGENTS.md) - Workspace documentation
-- **Sibling**: [halos-marine-containers](https://github.com/hatlabs/halos-marine-containers) - Marine container store
-- **Tooling**: [container-packaging-tools](https://github.com/hatlabs/container-packaging-tools)
+- **Sibling**: [halos-marine-containers](https://github.com/halos-org/halos-marine-containers) - Marine container store
+- **Tooling**: [container-packaging-tools](https://github.com/halos-org/container-packaging-tools)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For development with AI assistants, use the halos-distro workspace for full cont
 
 ```bash
 # Clone the workspace
-git clone https://github.com/hatlabs/halos-distro.git
+git clone https://github.com/halos-org/halos-distro.git
 cd halos-distro
 
 # Get all sub-repositories including halos-core-containers
@@ -92,10 +92,10 @@ ls build/*.deb
 
 ## Related Repositories
 
-- [halos-distro](https://github.com/hatlabs/halos-distro) - HaLOS workspace and planning
-- [halos-marine-containers](https://github.com/hatlabs/halos-marine-containers) - Marine container store
-- [cockpit-apt](https://github.com/hatlabs/cockpit-apt) - APT package manager with store filtering
-- [container-packaging-tools](https://github.com/hatlabs/container-packaging-tools) - Package generation tooling
+- [halos-distro](https://github.com/halos-org/halos-distro) - HaLOS workspace and planning
+- [halos-marine-containers](https://github.com/halos-org/halos-marine-containers) - Marine container store
+- [cockpit-apt](https://github.com/halos-org/cockpit-apt) - APT package manager with store filtering
+- [container-packaging-tools](https://github.com/halos-org/container-packaging-tools) - Package generation tooling
 - [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi) - APT repository infrastructure
 
 ## License

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Hat Labs <info@hatlabs.fi>
 Build-Depends: debhelper (>= 12)
 Standards-Version: 4.5.0
-Homepage: https://github.com/hatlabs/halos-core-containers
+Homepage: https://github.com/halos-org/halos-core-containers
 
 Package: halos-core-containers
 Architecture: all

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: halos-core-containers
 Upstream-Contact: Hat Labs <info@hatlabs.fi>
-Source: https://github.com/hatlabs/halos-core-containers
+Source: https://github.com/halos-org/halos-core-containers
 
 Files: *
 Copyright: 2024-2025 Hat Labs

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ long_description: |
   Traefik handles HTTPS termination and routing, Authelia provides
   authentication, and Homarr serves as the main user interface.
 
-homepage: https://github.com/hatlabs/halos-core-containers
+homepage: https://github.com/halos-org/halos-core-containers
 maintainer: Hat Labs <info@hatlabs.fi>
 license: MIT
 


### PR DESCRIPTION
## Summary

- Update all GitHub organization references from `hatlabs` to `halos-org` for transferred repositories
- CI workflow references, package metadata, documentation links, and other org-specific URLs

Part of the HaLOS org migration from `hatlabs` to `halos-org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)