### PR TITLE
chore: update workspace references for halos-distro → halos rename

### DIFF
--- a/.github/scripts/check-hardcoded-hostnames.sh
+++ b/.github/scripts/check-hardcoded-hostnames.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Lint check for hard-coded hostname references.
-# See docs/HOSTNAME_POLICY.md in halos-distro for the full policy.
+# See docs/HOSTNAME_POLICY.md in halos for the full policy.
 #
 # Usage: Run from repository root.
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,16 @@
 
 ## For Agentic Coding: Use the HaLOS Workspace
 
-This repository should be used as part of the halos-distro workspace for AI-assisted development:
+This repository should be used as part of the halos workspace for AI-assisted development:
 
 ```bash
 # Clone workspace and all repos
-git clone https://github.com/halos-org/halos-distro.git
-cd halos-distro
+git clone https://github.com/halos-org/halos.git
+cd halos
 ./run repos:clone
 ```
 
-See `halos-distro/docs/` for development workflows and guidance.
+See `halos/docs/` for development workflows and guidance.
 
 ## About This Project
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ All packages are published to apt.hatlabs.fi.
 
 ## Agentic Coding Setup (Claude Code, GitHub Copilot, etc.)
 
-For development with AI assistants, use the halos-distro workspace for full context:
+For development with AI assistants, use the halos workspace for full context:
 
 ```bash
 # Clone the workspace
-git clone https://github.com/halos-org/halos-distro.git
-cd halos-distro
+git clone https://github.com/halos-org/halos.git
+cd halos
 
 # Get all sub-repositories including halos-core-containers
 ./run repos:clone
@@ -48,7 +48,7 @@ cd halos-distro
 # Claude Code gets full context across all repos
 ```
 
-See `halos-distro/docs/` for development workflows:
+See `halos/docs/` for development workflows:
 - `LIFE_WITH_CLAUDE.md` - Quick start guide
 - `IMPLEMENTATION_CHECKLIST.md` - Development checklist
 - `DEVELOPMENT_WORKFLOW.md` - Detailed workflows
@@ -92,7 +92,7 @@ ls build/*.deb
 
 ## Related Repositories
 
-- [halos-distro](https://github.com/halos-org/halos-distro) - HaLOS workspace and planning
+- [halos](https://github.com/halos-org/halos) - HaLOS workspace and planning
 - [halos-marine-containers](https://github.com/halos-org/halos-marine-containers) - Marine container store
 - [cockpit-apt](https://github.com/halos-org/cockpit-apt) - APT package manager with store filtering
 - [container-packaging-tools](https://github.com/halos-org/container-packaging-tools) - Package generation tooling


### PR DESCRIPTION
## Summary
- Update all `halos-distro` references to `halos` following the workspace repo rename

## Test plan
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)