### PR TITLE
Fix YAML escape in redirect regex and add bare-path routers

### DIFF
--- a/assets/configure-container-routing
+++ b/assets/configure-container-routing
@@ -171,6 +171,15 @@ http:
         - redirect-${app_id}
       service: noop@internal
       priority: 100
+    redirect-${app_id}-bare:
+      rule: "Host(\`${HALOS_DOMAIN}\`) && Path(\`/${app_id}\`)"
+      entrypoints:
+        - websecure
+      tls: {}
+      middlewares:
+        - add-slash-${app_id}
+      service: noop@internal
+      priority: 101
     redirect-${app_id}-http:
       rule: "Host(\`${HALOS_DOMAIN}\`) && PathPrefix(\`/${app_id}/\`)"
       entrypoints:
@@ -179,11 +188,24 @@ http:
         - redirect-to-https
       service: noop@internal
       priority: 100
+    redirect-${app_id}-bare-http:
+      rule: "Host(\`${HALOS_DOMAIN}\`) && Path(\`/${app_id}\`)"
+      entrypoints:
+        - web
+      middlewares:
+        - redirect-to-https
+      service: noop@internal
+      priority: 101
   middlewares:
     redirect-${app_id}:
       redirectRegex:
         regex: "^https://([^/]+)/${app_id}/(.*)"
-        replacement: "https://\\\${1}:${external_port}/\\\${2}"
+        replacement: "https://\${1}:${external_port}/\${2}"
+        permanent: false
+    add-slash-${app_id}:
+      redirectRegex:
+        regex: "^https://([^/]+)/${app_id}$"
+        replacement: "https://\${1}/${app_id}/"
         permanent: false
 EOF
 

--- a/prestart.sh
+++ b/prestart.sh
@@ -131,6 +131,15 @@ http:
         - cockpit-redirect
       service: noop@internal
       priority: 100
+    cockpit-redirect-bare:
+      rule: "Host(\`${HALOS_DOMAIN}\`) && Path(\`/cockpit\`)"
+      entrypoints:
+        - websecure
+      tls: {}
+      middlewares:
+        - cockpit-add-slash
+      service: noop@internal
+      priority: 101
     cockpit-redirect-http:
       rule: "Host(\`${HALOS_DOMAIN}\`) && PathPrefix(\`/cockpit/\`)"
       entrypoints:
@@ -139,11 +148,24 @@ http:
         - redirect-to-https
       service: noop@internal
       priority: 100
+    cockpit-redirect-bare-http:
+      rule: "Host(\`${HALOS_DOMAIN}\`) && Path(\`/cockpit\`)"
+      entrypoints:
+        - web
+      middlewares:
+        - redirect-to-https
+      service: noop@internal
+      priority: 101
   middlewares:
     cockpit-redirect:
       redirectRegex:
         regex: "^https://([^/]+)/cockpit/(.*)"
-        replacement: "https://\\\${1}:9090/\\\${2}"
+        replacement: "https://\${1}:9090/\${2}"
+        permanent: false
+    cockpit-add-slash:
+      redirectRegex:
+        regex: "^https://([^/]+)/cockpit$"
+        replacement: "https://\${1}/cockpit/"
         permanent: false
 EOF
 chmod 644 "${COCKPIT_CONFIG_FILE}"


### PR DESCRIPTION
## Summary
- Fix invalid YAML escape `\${1}` in redirect regex replacement strings (should be `${1}`)
- Add bare-path routers (`/app-id` without trailing slash → redirect to `/app-id/`) to prevent 404s

The YAML escape error prevented Traefik's file provider from loading ANY dynamic config, breaking all file-based routers including redirects, TLS defaults, and the `redirect-to-https` middleware.

## Test plan
- [ ] `curl -sk https://halosdev.local/signalk-server/` → 302 to `:4430`
- [ ] `curl -sk https://halosdev.local/signalk-server` → 301 to `/signalk-server/`
- [ ] `curl -sk https://halosdev.local/cockpit/` → 302 to `:9090`
- [ ] `curl -sk https://halosdev.local/cockpit` → 301 to `/cockpit/`
- [ ] Traefik logs show no YAML parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)