### PR TITLE
Fix Authelia OIDC issuer trailing slash mismatch

### DIFF
--- a/assets/authelia/configuration.yml.template
+++ b/assets/authelia/configuration.yml.template
@@ -5,7 +5,7 @@
 theme: auto
 
 server:
-  address: tcp://0.0.0.0:9091/auth
+  address: tcp://0.0.0.0:9091/auth/
 
 log:
   level: info


### PR DESCRIPTION
## Summary
Add trailing slash to Authelia's `server.address` path prefix (`/auth` → `/auth/`) so the OIDC issuer URL matches what clients expect.

Without the slash, Authelia sets issuer to `https://host/auth` but Signal K expects `https://host/auth/`, causing `ID token issuer mismatch` errors after OIDC login.

## Test plan
- [ ] Signal K OIDC login completes without issuer mismatch error
- [ ] Authelia UI accessible at `/auth/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)