### PR TITLE
Fix OIDC issuer: remove trailing slash from /auth/

### DIFF
--- a/assets/authelia/configuration.yml.template
+++ b/assets/authelia/configuration.yml.template
@@ -5,7 +5,7 @@
 theme: auto
 
 server:
-  address: tcp://0.0.0.0:9091/auth/
+  address: tcp://0.0.0.0:9091/auth
 
 log:
   level: info
@@ -38,7 +38,7 @@ session:
     maximum_active_connections: 8
   cookies:
     - domain: '${HALOS_DOMAIN}'
-      authelia_url: 'https://${HALOS_DOMAIN}/auth/'
+      authelia_url: 'https://${HALOS_DOMAIN}/auth'
       default_redirection_url: 'https://${HALOS_DOMAIN}'
 
 storage:

--- a/prestart.sh
+++ b/prestart.sh
@@ -273,7 +273,7 @@ fi
 # Set OIDC configuration for Homarr
 declare -A HOMARR_SSO_CONFIG=(
     ["AUTH_PROVIDERS"]="oidc"
-    ["AUTH_OIDC_ISSUER"]="https://${HALOS_DOMAIN}/auth/"
+    ["AUTH_OIDC_ISSUER"]="https://${HALOS_DOMAIN}/auth"
     ["AUTH_OIDC_CLIENT_ID"]="homarr"
     ["AUTH_OIDC_CLIENT_SECRET"]="${OIDC_CLIENT_SECRET}"
     ["AUTH_OIDC_CLIENT_NAME"]="HaLOS"


### PR DESCRIPTION
## Summary
Revert the trailing slash on Authelia's `server.address` path — Authelia rejects paths ending with `/`. Update issuer and `authelia_url` to `https://host/auth` (no slash) to match Authelia's actual issuer.

## Test plan
- [ ] Authelia starts without errors
- [ ] OIDC login flow completes without issuer mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)