### PR TITLE
fix(routing): log to stderr to prevent YAML corruption on first app install

### DIFF
--- a/assets/configure-container-routing
+++ b/assets/configure-container-routing
@@ -36,7 +36,7 @@ if [ -z "${HALOS_DOMAIN}" ]; then
 fi
 
 log() {
-    echo "[configure-container-routing] $1"
+    echo "[configure-container-routing] $1" >&2
 }
 
 # Parse YAML value - simple grep-based parser for our known format

--- a/assets/traefik/generate-routing-labels.sh
+++ b/assets/traefik/generate-routing-labels.sh
@@ -27,7 +27,7 @@ if [ -z "${HALOS_DOMAIN}" ]; then
 fi
 
 log() {
-    echo "[generate-routing-labels] $1"
+    echo "[generate-routing-labels] $1" >&2
 }
 
 # Main: Process all routing files using configure-container-routing


### PR DESCRIPTION
## Summary

- Fix `configure-container-routing` log function to write to stderr instead of stdout

## Motivation

When a container app is installed for the first time, `get_or_assign_port()` assigns a new port and calls `log()` to report it. Since `log()` writes to stdout and the function's return value is captured via command substitution, the log message gets concatenated with the port number:

```
external_port="[configure-container-routing] Assigned port 4431 to avnav\n4431"
```

This corrupted value is interpolated into the docker-compose override YAML template, causing:

```
yaml: line 6: could not find expected ':'
```

The service then crashes and restarts. On retry, the port is already in the registry so the log line is skipped and it works — but every first-time app install fails once.

Fix: `>&2` on the `log()` echo.

## Test plan

- [ ] Install a new container app on a test device (one not previously installed)
- [ ] Verify it starts on the first attempt without YAML errors
- [ ] Verify existing apps still start correctly after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)