### PR TITLE
Add Docker healthchecks to Traefik and Homarr

### DIFF
--- a/assets/traefik/traefik.yml
+++ b/assets/traefik/traefik.yml
@@ -65,5 +65,7 @@ entryPoints:
   app-4450:
     address: ":4450"
 
+ping: {}
+
 log:
   level: INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,12 @@ services:
     extra_hosts:
       # Required for host networking apps (Traefik routes to host IP)
       - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/ping"]
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     networks:
       - proxy
     logging:
@@ -142,6 +148,12 @@ services:
       - /usr/share/pixmaps:/usr/share/pixmaps:ro
       - /usr/share/halos-homarr-branding:/usr/share/halos-homarr-branding:ro
       - /var/lib/container-apps:/var/lib/container-apps:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:7575"]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
     networks:
       - proxy
     labels:


### PR DESCRIPTION
## Summary

- Enable Traefik's built-in `ping` endpoint in static config
- Add healthcheck to Traefik (hits `/ping` on the API entrypoint :8080)
- Add healthcheck to Homarr (hits localhost:7575)

Combined with the existing `autoheal` container, this enables automatic restart of Traefik and Homarr if they become unresponsive.

Closes #118

## Test plan

- [ ] Deploy and verify `docker inspect traefik` shows healthcheck config
- [ ] Verify `docker inspect homarr` shows healthcheck config
- [ ] Confirm both containers reach `healthy` status (`docker ps`)
- [ ] Verify autoheal detects and restarts a manually broken container

🤖 Generated with [Claude Code](https://claude.com/claude-code)