### PR TITLE
fix(certs): three deployment bugs in /halos-ca.crt endpoint

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,16 +26,19 @@ override_dh_auto_install:
 	install -D -m 644 icon.png \
 		debian/$(PKG_NAME)/usr/share/pixmaps/$(PKG_NAME).png
 
-	# Install assets (preserving directory structure, +x for .sh files).
-	# IMPORTANT: every assets/<dir>/ that docker-compose.yml bind-mounts
-	# from must appear in this list. Missing dirs ship as nothing; Docker
-	# then creates an empty *directory* at the bind-mount source path on
-	# first start, the bind into the container fails with "not a
-	# directory", and the affected container loops on container-init
-	# error. Lost ca-download/ for an entire release cycle exactly this
-	# way — keep this list in sync with docker-compose.yml volume mounts.
-	for dir in traefik authelia homarr ca-download; do \
-		find assets/$$dir -type f | while read f; do \
+	# Install every assets/<dir>/ tree, preserving directory structure, with
+	# +x on .sh files. The glob (over the previous hardcoded list) makes the
+	# class of bug structurally impossible: any new asset subdir added for a
+	# docker-compose.yml bind-mount ships automatically. We lost ca-download/
+	# for a release cycle when the hardcoded list drifted from compose mounts
+	# — when a bind-mount source is missing, Docker creates an empty directory
+	# at the source path, the bind into the container fails with "not a
+	# directory", and the affected container loops on container-init error.
+	# Single-file assets (configure-container-routing, lib-*.sh, hostnames.conf)
+	# are installed explicitly below and not under assets/<dir>/, so the glob
+	# does not over-capture.
+	for dir in assets/*/; do \
+		find "$$dir" -type f | while read f; do \
 			case "$$f" in \
 				*.sh) install -D -m 755 "$$f" "debian/$(PKG_NAME)$(LIB_DIR)/$$f" ;; \
 				*) install -D -m 644 "$$f" "debian/$(PKG_NAME)$(LIB_DIR)/$$f" ;; \

--- a/debian/rules
+++ b/debian/rules
@@ -26,8 +26,15 @@ override_dh_auto_install:
 	install -D -m 644 icon.png \
 		debian/$(PKG_NAME)/usr/share/pixmaps/$(PKG_NAME).png
 
-	# Install assets (preserving directory structure, +x for .sh files)
-	for dir in traefik authelia homarr; do \
+	# Install assets (preserving directory structure, +x for .sh files).
+	# IMPORTANT: every assets/<dir>/ that docker-compose.yml bind-mounts
+	# from must appear in this list. Missing dirs ship as nothing; Docker
+	# then creates an empty *directory* at the bind-mount source path on
+	# first start, the bind into the container fails with "not a
+	# directory", and the affected container loops on container-init
+	# error. Lost ca-download/ for an entire release cycle exactly this
+	# way — keep this list in sync with docker-compose.yml volume mounts.
+	for dir in traefik authelia homarr ca-download; do \
 		find assets/$$dir -type f | while read f; do \
 			case "$$f" in \
 				*.sh) install -D -m 755 "$$f" "debian/$(PKG_NAME)$(LIB_DIR)/$$f" ;; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,13 @@ services:
       # /srv/halos-ca.crt marks the container unhealthy (autoheal then
       # restarts it). A bare /healthz probe stayed healthy while nginx
       # 404'd the cert, which hid breakage from operators.
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost/halos-ca.crt"]
+      #
+      # Connect via 127.0.0.1 (not localhost): nginx:alpine resolves
+      # localhost to ::1 first, and our nginx.conf only `listen 80` on
+      # IPv4. localhost probes get ECONNREFUSED → container stays
+      # unhealthy → Traefik 3.7 filters unhealthy containers from
+      # discovery → endpoint silently unreachable behind a homarr 404.
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1/halos-ca.crt"]
       interval: 10s
       timeout: 5s
       start_period: 30s

--- a/docs/CERTS.md
+++ b/docs/CERTS.md
@@ -70,7 +70,7 @@ The active CA is published at:
 
     https://<host>/halos-ca.crt
 
-Plain HTTP requests to the same path are redirected to HTTPS (301). The
+Plain HTTP requests to the same path are redirected to HTTPS (308). The
 sidecar that serves the file returns it with:
 
 | Header                | Value                                       |
@@ -131,7 +131,7 @@ ssh halos.local 'sudo cat /var/lib/container-apps/halos-core-containers/data/hal
 curl -skI https://halos.local/halos-ca.crt | grep -iE 'content-(type|disposition)'
 
 # 3. HTTP redirects to HTTPS.
-curl -sI http://halos.local/halos-ca.crt | head -1   # 301 Moved Permanently
+curl -sI http://halos.local/halos-ca.crt | head -1   # 308 Permanent Redirect
 curl -sI http://halos.local/halos-ca.crt | grep -i ^location
 
 # 4. After swapping the active CA (operator drops files in /etc/halos/ca/


### PR DESCRIPTION
Three deployment bugs caught while testing `v0.3.4-4` (the unstable build from PR #136) on `halosdev.local`. Each one independently broke the `/halos-ca.crt` endpoint despite passing CI and the multi-persona `ce:review`.

## 1. `debian/rules` didn't ship `assets/ca-download/nginx.conf`

The asset-install loop hardcoded `traefik authelia homarr` — the new `ca-download/` directory was silently skipped:

```
for dir in traefik authelia homarr; do ...
```

When the bind-mount source file is missing, Docker creates an empty *directory* at the source path. The bind into the container then fails with `not a directory`, and the container loops on init error before nginx even starts. The fix adds `ca-download` to the loop and a load-bearing comment so future `docker-compose.yml` bind-mount additions don't re-introduce the same gap.

## 2. Healthcheck `localhost` → IPv6 → unhealthy → invisible to Traefik

`docker-compose.yml` healthcheck probed `http://localhost/halos-ca.crt`. `nginx:alpine` resolves `localhost` to `::1` first, and our `nginx.conf` only `listen 80` (IPv4). Every probe got `ECONNREFUSED`, the container stayed unhealthy, and **Traefik 3.7's docker provider filters unhealthy containers from discovery** — so the `ca-download` routers never registered and `/halos-ca.crt` silently fell through to Homarr's catch-all (a Next.js 404).

Fix: probe `127.0.0.1` directly. Container goes healthy → Traefik registers the routers → end-to-end works.

## 3. `docs/CERTS.md` claimed 301; actual is 308

The `ce:review` api-contract reviewer claimed Traefik's `redirectScheme(permanent: true)` emits `301 Moved Permanently`. Traefik 3.7 actually emits `308 Permanent Redirect`. Verified on the device with `curl -sI`. Updated the two places that referenced the code.

## Verification

Tested on `halosdev.local` after side-loading the missing `nginx.conf` and patching the healthcheck in place:

```
$ curl -skI https://halosdev.local/halos-ca.crt | head -3
HTTP/2 200
content-disposition: attachment; filename="halos-ca.crt"
content-type: application/x-x509-ca-cert

$ diff <(ssh halosdev.local 'sudo cat .../serving-ca.crt') <(curl -sk https://halosdev.local/halos-ca.crt)
# (no output — bytes match)

$ curl -sI http://halosdev.local/halos-ca.crt | head -1
HTTP/1.1 308 Permanent Redirect

$ curl -skI -X POST https://halosdev.local/halos-ca.crt | head -1
HTTP/2 403   # blocked correctly (limit_except returns 403, not 405)
```

## Why CI didn't catch these

- `debian/rules` install loop: no test exercises the actual `.deb` install + first-boot flow. `docker compose config` passes the YAML.
- IPv6 healthcheck: no test brings up the sidecar in an environment that mimics the alpine `localhost` resolution behavior.
- 301 vs 308: the api-contract reviewer guessed from docs/training; the actual emitter wasn't checked.

A device-bring-up smoke test in CI (or a release-gate check that does `apt install + systemctl start`) would have caught (1) and (2). Worth a follow-up issue.

Refs #129, refs #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)