### PR TITLE
feat(certs): extract cert management into halos-manage-certs.service (closes #139)

### DIFF
--- a/assets/halos-manage-certs
+++ b/assets/halos-manage-certs
@@ -1,0 +1,216 @@
+#!/bin/bash
+# halos-manage-certs — provision and maintain HaLOS device CA + leaf cert
+#
+# Runs as a systemd oneshot ordered Before=halos-core-containers.service.
+# Also invoked by halos-manage-certs.timer (see #140) for periodic renewal
+# checks against Apple's 825-day leaf-validity ceiling. Idempotent on every
+# invocation:
+#   - reuses an existing healthy auto-CA; rotates on expiry / clock-skew
+#   - re-signs the leaf only when the sentinel mismatches OR the leaf is
+#     within HALOS_CA_LEAF_RENEW_THRESHOLD_DAYS of expiry
+#   - re-publishes the public CA copy unconditionally (cheap, self-heals)
+#   - re-installs the cockpit override unconditionally (cheap, self-heals)
+#
+# Auxiliary failures (public-CA publish, cockpit override install) log WARN
+# and continue. The leaf and its CA are the hard prerequisites for the
+# container stack; everything else is opportunistic.
+#
+# Path-related state can be overridden via env for tests:
+#   HALOS_ETC_DIR              /etc/container-apps/<pkg>
+#   HALOS_LIB_HOSTNAMES        /usr/lib/<pkg>/lib-hostnames.sh
+#   HALOS_LIB_CA               /usr/lib/<pkg>/lib-ca.sh
+#   HALOS_CUSTOM_CA_DIR        /etc/halos/ca
+#   HALOS_COCKPIT_WS_CERTS_DIR /etc/cockpit/ws-certs.d
+
+set -e
+
+PACKAGE_NAME="${PACKAGE_NAME:-halos-core-containers}"
+ETC_DIR="${HALOS_ETC_DIR:-/etc/container-apps/${PACKAGE_NAME}}"
+
+# env.defaults carries CONTAINER_DATA_ROOT and PACKAGE_NAME (the postinst
+# writes both). `set -a` exports newly-assigned vars so lib functions see
+# them without per-assignment export. Tests skip env.defaults by passing
+# CONTAINER_DATA_ROOT directly and pointing HALOS_ETC_DIR at an empty dir.
+set -a
+[ -f "${ETC_DIR}/env.defaults" ] && . "${ETC_DIR}/env.defaults"
+[ -f "${ETC_DIR}/env" ] && . "${ETC_DIR}/env"
+set +a
+
+: "${CONTAINER_DATA_ROOT:=/var/lib/container-apps/${PACKAGE_NAME}}"
+
+LIB_HOSTNAMES="${HALOS_LIB_HOSTNAMES:-/usr/lib/halos-core-containers/lib-hostnames.sh}"
+LIB_CA="${HALOS_LIB_CA:-/usr/lib/halos-core-containers/lib-ca.sh}"
+
+# shellcheck source=assets/lib-hostnames.sh
+. "$LIB_HOSTNAMES"
+# shellcheck source=assets/lib-ca.sh
+. "$LIB_CA"
+
+halos_load_hostnames
+HALOS_DOMAIN="$(halos_canonical_hostname)"
+
+echo "HaLOS cert management — domain: ${HALOS_DOMAIN}"
+
+# TLS Certificate Hierarchy ---------------------------------------------------
+#
+# Per-device CA signs a leaf used by Traefik (:443) and shared into Cockpit
+# (:9090) via a combined-PEM override. Operators can install the CA in their
+# OS trust store so all of the device's HTTPS endpoints validate.
+#
+# Two CA-source modes, picked by halos_ca_select_active:
+#   - custom: operator dropped /etc/halos/ca/ca.{crt,key} and the pair validates
+#   - auto:   no custom present → auto-generated per-device CA
+# The active CA is exposed via the serving-ca.crt symlink so the ca-download
+# sidecar always reads "whichever CA is active right now".
+#
+# Layout:
+#   ${CUSTOM_CA_DIR}/ca.{crt,key}         optional operator-supplied custom CA
+#   ${AUTO_CA_DIR}/ca.{crt,key}           auto-generated device CA (20y)
+#   ${AUTO_CA_DIR}/serving-ca.crt         symlink → active CA cert
+#   ${CERTS_DIR}/halos.{crt,key}          leaf signed by active CA (~824d)
+#   ${CERTS_DIR}/.domain                  sentinel: "<hostname-hash>:<ca-fingerprint>"
+CUSTOM_CA_DIR="${HALOS_CUSTOM_CA_DIR:-/etc/halos/ca}"
+AUTO_CA_DIR="${CONTAINER_DATA_ROOT}/${PACKAGE_NAME}/certs/ca"
+SERVING_CA="${AUTO_CA_DIR}/serving-ca.crt"
+TRAEFIK_DATA="${CONTAINER_DATA_ROOT}/traefik"
+CERTS_DIR="${TRAEFIK_DATA}/certs"
+CERT_FILE="${CERTS_DIR}/halos.crt"
+KEY_FILE="${CERTS_DIR}/halos.key"
+DOMAIN_FILE="${CERTS_DIR}/.domain"
+PUBLIC_CA_DIR="${CONTAINER_DATA_ROOT}/${PACKAGE_NAME}/certs/public"
+COCKPIT_WS_CERTS_DIR="${HALOS_COCKPIT_WS_CERTS_DIR:-/etc/cockpit/ws-certs.d}"
+COCKPIT_LEAF_OVERRIDE="${COCKPIT_WS_CERTS_DIR}/99-halos.cert"
+
+mkdir -p "${CERTS_DIR}"
+
+# Select active CA. Custom (when present + valid) wins; otherwise auto is
+# ensured/rotated. A broken custom CA aborts cert management rather than
+# silently falling back — operators who installed a custom CA can SSH to
+# diagnose, and silent fallback would orphan the trust anchor they
+# distributed.
+halos_ca_select_active "${CUSTOM_CA_DIR}" "${AUTO_CA_DIR}" "${SERVING_CA}"
+CA_CRT="${HALOS_CA_ACTIVE_CRT}"
+CA_KEY="${HALOS_CA_ACTIVE_KEY}"
+echo "Active CA: ${CA_CRT} (mode=${HALOS_CA_ACTIVE_MODE})"
+
+# Publish the active CA's PEM bytes into the public dir the ca-download
+# sidecar bind-mounts. Refreshed unconditionally so the published bytes
+# track whichever CA halos_ca_select_active picked.
+#
+# Auxiliary: failure does NOT abort. The previous public copy (if any) is
+# preserved by the helper; consumers of /halos-ca.crt keep serving the
+# old bytes until the next successful run.
+if ! halos_ca_publish_public "${HALOS_CA_ACTIVE_CRT}" "${PUBLIC_CA_DIR}"; then
+    echo "WARNING: failed to refresh public CA copy at ${PUBLIC_CA_DIR}/halos-ca.crt; the /halos-ca.crt download endpoint may serve stale or no CA until the next successful run." >&2
+fi
+
+# Explicit guard: `set -e` does NOT abort on command-substitution failure
+# in an assignment. Without it, a corrupt CA silently yields CA_FINGERPRINT=""
+# and feeds a malformed sentinel into downstream comparison — an infinite
+# re-sign loop.
+CA_FINGERPRINT=$(halos_ca_fingerprint "${CA_CRT}") || {
+    echo "halos-manage-certs: failed to compute CA fingerprint; cert generation cannot continue" >&2
+    exit 1
+}
+
+HOSTNAMES_HASH="$(halos_hostnames_hash)"
+SENTINEL="$(halos_ca_sentinel_compose "${HOSTNAMES_HASH}" "${CA_FINGERPRINT}")"
+NEED_LEAF=false
+if [ ! -f "${CERT_FILE}" ] || [ ! -f "${KEY_FILE}" ]; then
+    echo "Leaf certificate files not found, generating..."
+    NEED_LEAF=true
+elif [ -f "${DOMAIN_FILE}" ]; then
+    STORED=$(cat "${DOMAIN_FILE}")
+    case "$(halos_ca_sentinel_classify "${STORED}")" in
+        match-shape)
+            if [ "${STORED}" != "${SENTINEL}" ]; then
+                echo "Hostname list or CA changed, re-signing leaf certificate..."
+                NEED_LEAF=true
+            fi
+            ;;
+        legacy)
+            echo "Legacy cert sentinel detected, migrating to combined hostname+CA sentinel..."
+            NEED_LEAF=true
+            ;;
+        unrecognized)
+            echo "Cert sentinel unrecognized or corrupt, regenerating leaf certificate..."
+            NEED_LEAF=true
+            ;;
+    esac
+else
+    echo "Cert tracking file not found, regenerating leaf certificate..."
+    NEED_LEAF=true
+fi
+
+# Time-based renewal gate, independent of sentinel state. Catches the
+# unchanged-config device that would otherwise keep the same leaf until
+# Apple's 825-day ceiling expires it (rejection in Safari, Brave,
+# /usr/bin/curl, every SecTrustEvaluate consumer). Fires when remaining
+# validity drops below HALOS_CA_LEAF_RENEW_THRESHOLD_DAYS — paired with
+# this script's periodic invocation via halos-manage-certs.timer (#140),
+# the leaf rotates without operator action.
+if [ "${NEED_LEAF}" != true ] && halos_ca_leaf_needs_renewal "${CERT_FILE}"; then
+    echo "Leaf within renewal threshold (${HALOS_CA_LEAF_RENEW_THRESHOLD_DAYS}d remaining), re-signing..."
+    NEED_LEAF=true
+fi
+
+if [ "${NEED_LEAF}" = true ]; then
+    # Invalidate the sentinel BEFORE attempting to re-sign. If halos_ca_sign_leaf
+    # partially succeeds (key swapped, cert mv fails) and we exit, the sentinel
+    # is gone — so the next run detects "no sentinel" and retries rather than
+    # seeing stale "everything matches" and silently skipping past a key/cert
+    # mismatch that would break TLS handshakes.
+    rm -f "${DOMAIN_FILE}"
+
+    # Build subjectAltName: DNS: entries followed by IP: entries, each sorted
+    # for deterministic output. Loader-validated values; still quote at use
+    # site (defense-in-depth).
+    SAN_ENTRIES=""
+    while IFS= read -r dns_entry; do
+        [ -z "$dns_entry" ] && continue
+        SAN_ENTRIES="${SAN_ENTRIES}${SAN_ENTRIES:+,}DNS:${dns_entry}"
+    done < <(halos_dns_hostnames | LC_ALL=C sort)
+    if [ "${#HALOS_HOSTNAMES_IPS[@]}" -gt 0 ]; then
+        while IFS= read -r ip_entry; do
+            [ -z "$ip_entry" ] && continue
+            SAN_ENTRIES="${SAN_ENTRIES}${SAN_ENTRIES:+,}IP:${ip_entry}"
+        done < <(printf '%s\n' "${HALOS_HOSTNAMES_IPS[@]}" | LC_ALL=C sort)
+    fi
+
+    echo "Signing TLS leaf certificate (CN=${HALOS_DOMAIN}, SANs=${SAN_ENTRIES})..."
+    halos_ca_sign_leaf \
+        "${CA_CRT}" "${CA_KEY}" \
+        "${CERT_FILE}" "${KEY_FILE}" \
+        "${SAN_ENTRIES}" "${HALOS_DOMAIN}"
+    printf '%s' "${SENTINEL}" > "${DOMAIN_FILE}"
+    echo "Leaf certificate signed successfully"
+else
+    echo "Using existing leaf certificate for ${HALOS_DOMAIN}"
+fi
+
+# Share the leaf with Cockpit (:9090) by installing a combined-PEM override at
+# ${COCKPIT_WS_CERTS_DIR}/99-halos.cert. cockpit-tls picks the lex-last *.cert
+# file at socket activation, so the 99- prefix overrides the upstream
+# 0-self-signed.cert generated by cockpit-certificate-ensure. The upstream
+# cert stays as the safety-net floor — removing 99-halos.cert reverts Cockpit
+# to upstream-generated self-signed without further action. See docs/CERTS.md.
+#
+# Runs UNCONDITIONALLY: cheap (cert+key concat) and self-heals if the
+# override was deleted manually. Skipped (with a log line) when the
+# cockpit-ws dir doesn't exist — the cockpit package is only pulled in via
+# halos-cockpit-config's Recommends, so install-order variance can leave the
+# dir absent for a window.
+if [ -d "${COCKPIT_WS_CERTS_DIR}" ]; then
+    echo "Installing Cockpit leaf cert override at ${COCKPIT_LEAF_OVERRIDE}..."
+    # Tolerate failure: cockpit override is auxiliary. Upstream's
+    # 0-self-signed.cert remains the safety-net floor. Letting a transient
+    # cockpit-install failure abort would mean cert management never
+    # completes successfully, blocking halos-core-containers from starting.
+    if ! halos_cockpit_install_leaf "${CERT_FILE}" "${KEY_FILE}" "${COCKPIT_LEAF_OVERRIDE}"; then
+        echo "WARNING: Cockpit leaf cert install failed; :9090 keeps its previous cert (upstream self-signed if no prior override)." >&2
+    fi
+else
+    echo "Skipping Cockpit leaf cert install: ${COCKPIT_WS_CERTS_DIR} does not exist (cockpit-ws not yet installed)"
+fi
+
+echo "HaLOS cert management complete"

--- a/assets/halos-manage-certs
+++ b/assets/halos-manage-certs
@@ -27,10 +27,14 @@ set -e
 PACKAGE_NAME="${PACKAGE_NAME:-halos-core-containers}"
 ETC_DIR="${HALOS_ETC_DIR:-/etc/container-apps/${PACKAGE_NAME}}"
 
-# env.defaults carries CONTAINER_DATA_ROOT and PACKAGE_NAME (the postinst
-# writes both). `set -a` exports newly-assigned vars so lib functions see
-# them without per-assignment export. Tests skip env.defaults by passing
-# CONTAINER_DATA_ROOT directly and pointing HALOS_ETC_DIR at an empty dir.
+# env.defaults (written by postinst) is the source of truth for
+# CONTAINER_DATA_ROOT and PACKAGE_NAME in production. `set -a` exports
+# newly-assigned vars so lib functions see them without per-assignment
+# export. Precedence: env.defaults > env > caller-supplied env > the
+# defaults at lines 27 and 41. To override PACKAGE_NAME or
+# CONTAINER_DATA_ROOT in a test, point HALOS_ETC_DIR at a tmpdir with NO
+# env.defaults and set the values in the caller env — otherwise the
+# sourced env.defaults clobbers caller values.
 set -a
 [ -f "${ETC_DIR}/env.defaults" ] && . "${ETC_DIR}/env.defaults"
 [ -f "${ETC_DIR}/env" ] && . "${ETC_DIR}/env"

--- a/assets/lib-ca.sh
+++ b/assets/lib-ca.sh
@@ -2,7 +2,7 @@
 # lib-ca.sh — Shared shell library for HaLOS device-CA + leaf cert management.
 #
 # Sourced by:
-#   - halos-core-containers/prestart.sh
+#   - /usr/lib/halos-core-containers/halos-manage-certs
 #
 # Provides:
 #   - halos_ca_ensure_auto <dir>          generate/refresh auto-CA at <dir>/ca.{crt,key}

--- a/assets/lib-hostnames.sh
+++ b/assets/lib-hostnames.sh
@@ -3,6 +3,7 @@
 #
 # Sourced by:
 #   - halos-core-containers/prestart.sh
+#   - /usr/lib/halos-core-containers/halos-manage-certs
 #   - /usr/bin/configure-container-routing
 #   - /usr/bin/reload-oidc-clients
 #

--- a/debian/halos-core-containers.halos-manage-certs.service
+++ b/debian/halos-core-containers.halos-manage-certs.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Provision and maintain HaLOS device CA + leaf TLS certificate
+Documentation=https://github.com/halos-org/halos-core-containers
+After=local-fs.target
+Before=halos-core-containers.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/halos-core-containers/halos-manage-certs
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=halos-core-containers.service

--- a/debian/halos-core-containers.halos-manage-certs.service
+++ b/debian/halos-core-containers.halos-manage-certs.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Provision and maintain HaLOS device CA + leaf TLS certificate
-Documentation=https://github.com/halos-org/halos-core-containers
+Documentation=https://github.com/halos-org/halos-core-containers/blob/main/docs/CERTS.md
 After=local-fs.target
 Before=halos-core-containers.service
 

--- a/debian/halos-core-containers.service
+++ b/debian/halos-core-containers.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=HaLOS Core Containers (Traefik, Authelia, Homarr)
-After=docker.service
-Requires=docker.service
+After=docker.service halos-manage-certs.service
+Requires=docker.service halos-manage-certs.service
 
 [Service]
 Type=simple

--- a/debian/postinst
+++ b/debian/postinst
@@ -64,8 +64,12 @@ EOF
             # Reload systemd to recognize new service
             systemctl daemon-reload
 
-            # Enable service
+            # Enable services. halos-manage-certs.service has
+            # WantedBy=halos-core-containers.service in [Install], so
+            # enabling it drops a wants/ symlink that pulls it in
+            # automatically whenever the container stack activates.
             systemctl enable ${PKG_NAME}.service || true
+            systemctl enable halos-manage-certs.service || true
         fi
         ;;
 esac

--- a/debian/rules
+++ b/debian/rules
@@ -58,6 +58,13 @@ override_dh_auto_install:
 	install -D -m 644 assets/lib-ca.sh \
 		debian/$(PKG_NAME)/usr/lib/$(PKG_NAME)/lib-ca.sh
 
+	# Install cert-management script. Executable but not under /usr/bin —
+	# it's a systemd-invoked helper (halos-manage-certs.service oneshot),
+	# not a general-purpose operator tool. Operators who need a manual
+	# force-refresh invoke it via `systemctl start halos-manage-certs`.
+	install -D -m 755 assets/halos-manage-certs \
+		debian/$(PKG_NAME)/usr/lib/$(PKG_NAME)/halos-manage-certs
+
 	# Install hostnames.conf as a Debian conffile (admin-managed; preserved on upgrade)
 	install -D -m 640 assets/hostnames.conf \
 		debian/$(PKG_NAME)/etc/halos/hostnames.conf

--- a/docs/CERTS.md
+++ b/docs/CERTS.md
@@ -2,6 +2,29 @@
 
 Operator notes on TLS certificate handling in halos-core-containers.
 
+## Where cert lifecycle lives
+
+All CA selection, leaf signing, public-CA publish, and Cockpit cert sharing
+runs in **`halos-manage-certs.service`** — a oneshot systemd unit ordered
+`Before=halos-core-containers.service`. The script (installed at
+`/usr/lib/halos-core-containers/halos-manage-certs`) is idempotent and runs
+on every container-stack activation, plus periodically via
+`halos-manage-certs.timer` (see issue #140) to catch the
+Apple-825-day-leaf-ceiling renewal case on devices that don't reboot often.
+
+`prestart.sh` no longer touches certs. To force a cert refresh without
+restarting the full container stack:
+
+```
+sudo systemctl start halos-manage-certs.service
+```
+
+Auxiliary failures (public-CA publish, Cockpit override install) log
+`WARNING` and do not block the unit. A broken operator-supplied custom CA
+in `/etc/halos/ca/` aborts the unit — and therefore blocks
+`halos-core-containers.service` start — because silently falling back to
+the auto-CA would orphan trust anchors the operator distributed to a fleet.
+
 ## Cockpit :9090 cert sharing
 
 Cockpit's `:9090` listener serves the same TLS leaf as Traefik, so operators see
@@ -32,10 +55,12 @@ sudo rm /etc/cockpit/ws-certs.d/99-halos.cert
 sudo systemctl restart cockpit
 ```
 
-Note: the next prestart run will re-create `99-halos.cert`. To make the revert
-persistent, you would also need to remove the call site from prestart.sh — but
-that defeats the purpose of the feature. The intended revert path is "remove
-the override, restart cockpit, verify expected behavior" for diagnosis only.
+Note: the next `halos-manage-certs.service` activation (next reboot, next
+`systemctl start halos-manage-certs`, or next timer fire) will re-create
+`99-halos.cert`. To make the revert persistent you would need to disable the
+service or remove the call site from `halos-manage-certs` — but that defeats
+the purpose of the feature. The intended revert path is "remove the
+override, restart cockpit, verify expected behavior" for diagnosis only.
 
 ### Picking up a new cert
 
@@ -110,10 +135,12 @@ verification, all `-sk` results are meaningless on an untrusted network.**
 ### After swapping in a custom CA
 
 When an operator drops a custom CA at `/etc/halos/ca/ca.{crt,key}`, the next
-`halos-core-containers.service` prestart copies the new cert to the public
-location and the URL serves the new bytes. Already-installed copies on
-operator workstations are NOT re-pushed — operators re-download and re-install
-on each machine that needs to trust the new CA.
+`halos-manage-certs.service` activation copies the new cert to the public
+location and the URL serves the new bytes. Triggers: next reboot, next
+`systemctl start halos-manage-certs`, or next timer fire (#140).
+Already-installed copies on operator workstations are NOT re-pushed —
+operators re-download and re-install on each machine that needs to trust
+the new CA.
 
 ### Test commands
 
@@ -135,8 +162,8 @@ curl -sI http://halos.local/halos-ca.crt | head -1   # 308 Permanent Redirect
 curl -sI http://halos.local/halos-ca.crt | grep -i ^location
 
 # 4. After swapping the active CA (operator drops files in /etc/halos/ca/
-#    and restarts halos-core-containers.service), the URL serves the new bytes.
-sudo systemctl restart halos-core-containers.service
+#    and re-runs cert management), the URL serves the new bytes.
+sudo systemctl start halos-manage-certs.service
 sleep 5
 curl -sk https://halos.local/halos-ca.crt -o /tmp/halos-ca-after.crt
 diff /tmp/halos-ca.crt /tmp/halos-ca-after.crt   # expect a diff

--- a/prestart.sh
+++ b/prestart.sh
@@ -67,12 +67,7 @@ if [ ! -f "${ACME_FILE}" ]; then
     echo "Created acme.json"
 fi
 
-# TLS leaf + CA artifacts are provisioned by halos-manage-certs.service
-# (oneshot, ordered Before=halos-core-containers.service). That unit owns
-# CA selection, leaf signing, public-CA publish, and the Cockpit cert
-# override. By the time prestart runs, the leaf files referenced by the
-# Traefik dynamic config below (/certs/halos.{crt,key}) already exist on
-# the data root. See docs/CERTS.md and assets/halos-manage-certs.
+# TLS leaf + CA artifacts are provisioned by a separate unit; see docs/CERTS.md.
 
 # Dynamic Configuration Directory
 DYNAMIC_DIR="/etc/halos/traefik-dynamic.d"

--- a/prestart.sh
+++ b/prestart.sh
@@ -34,16 +34,6 @@ fi
 . "$LIB_HOSTNAMES"
 halos_load_hostnames
 
-# Load CA helpers — generates and signs leaf with a device-level CA so
-# operators can install one trust anchor (vs the previous self-signed leaf
-# that browser trust stores reject as a root).
-LIB_CA="/usr/lib/halos-core-containers/lib-ca.sh"
-if [ ! -f "$LIB_CA" ]; then
-    LIB_CA="${SCRIPT_DIR}/assets/lib-ca.sh"
-fi
-# shellcheck source=assets/lib-ca.sh
-. "$LIB_CA"
-
 HOSTNAME_SHORT=$(hostname -s 2>/dev/null || hostname | cut -d. -f1)
 HALOS_DOMAIN="$(halos_canonical_hostname)"
 
@@ -77,172 +67,12 @@ if [ ! -f "${ACME_FILE}" ]; then
     echo "Created acme.json"
 fi
 
-# TLS Certificate Hierarchy
-#
-# Per-device CA signs a leaf for Traefik (and, in a follow-on unit, Cockpit's
-# :9090). The CA has CA:TRUE so an operator can install it in their OS trust
-# store and have all this device's services validate — something the previous
-# self-signed leaf could never offer.
-#
-# Two CA-source modes, picked by halos_ca_select_active:
-#   - custom: operator dropped /etc/halos/ca/ca.{crt,key} and the pair validates
-#   - auto:   no custom present → use the auto-generated per-device CA
-# The active CA is exposed via the serving-ca.crt symlink so consumers (Traefik
-# CA-download endpoint in Unit 4) always read "whichever CA is active right now".
-#
-# Layout:
-#   /etc/halos/ca/ca.{crt,key}            optional operator-supplied custom CA
-#   ${AUTO_CA_DIR}/ca.{crt,key}           auto-generated device CA (20y, persistent)
-#   ${AUTO_CA_DIR}/serving-ca.crt         symlink → active CA cert
-#   ${CERTS_DIR}/halos.{crt,key}          leaf signed by active CA (10y, multi-SAN)
-#   ${CERTS_DIR}/.domain                  sentinel: "<hostname-hash>:<ca-fingerprint>"
-CUSTOM_CA_DIR="/etc/halos/ca"
-AUTO_CA_DIR="${CONTAINER_DATA_ROOT}/${PACKAGE_NAME}/certs/ca"
-SERVING_CA="${AUTO_CA_DIR}/serving-ca.crt"
-CERTS_DIR="${TRAEFIK_DATA}/certs"
-CERT_FILE="${CERTS_DIR}/halos.crt"
-KEY_FILE="${CERTS_DIR}/halos.key"
-DOMAIN_FILE="${CERTS_DIR}/.domain"
-
-mkdir -p "${CERTS_DIR}"
-
-# Select the active CA. Custom (when present + valid) wins; otherwise auto is
-# ensured/rotated as needed. Failure on a broken custom CA aborts prestart
-# rather than silently falling back — operators who can install a custom CA
-# can SSH to diagnose, and silent fallback would orphan their installed trust
-# anchor.
-halos_ca_select_active "${CUSTOM_CA_DIR}" "${AUTO_CA_DIR}" "${SERVING_CA}"
-
-CA_CRT="${HALOS_CA_ACTIVE_CRT}"
-CA_KEY="${HALOS_CA_ACTIVE_KEY}"
-echo "Active CA: ${CA_CRT} (mode=${HALOS_CA_ACTIVE_MODE})"
-
-# Publish the active CA's PEM bytes to a public directory the ca-download
-# sidecar bind-mounts. Implementation + rationale (don't mount the symlink
-# directly; don't expose the custom-CA dir to the sidecar) lives in
-# halos_ca_publish_public — see assets/lib-ca.sh.
-#
-# Refreshed every prestart, BEFORE the leaf-signing path, so the published
-# bytes track whichever CA halos_ca_select_active picked — even on boots
-# that don't re-sign the leaf.
-#
-# Tolerate failure: the publish is auxiliary. If it fails (transient FS
-# hiccup, unreadable active CA mid-edit), let prestart continue so the rest
-# of the web stack (Traefik/Authelia/Homarr) still comes up. The previous
-# public copy (if any) is preserved by the helper.
-PUBLIC_CA_DIR="${CONTAINER_DATA_ROOT}/${PACKAGE_NAME}/certs/public"
-if ! halos_ca_publish_public "${HALOS_CA_ACTIVE_CRT}" "${PUBLIC_CA_DIR}"; then
-    echo "WARNING: failed to refresh public CA copy at ${PUBLIC_CA_DIR}/halos-ca.crt; the /halos-ca.crt download endpoint may serve stale or no CA until the next successful prestart. The rest of prestart continues." >&2
-fi
-
-# Explicit `|| exit` because bash `set -e` does NOT abort on a command-
-# substitution failure inside an assignment. Without this guard, a corrupt CA
-# would silently produce CA_FINGERPRINT="" and feed a malformed sentinel into
-# downstream comparison, causing an indefinite re-sign loop. halos_ca_fingerprint
-# returns non-zero and emits nothing on stdout when openssl can't parse the
-# cert, so this guard is the load-bearing piece.
-CA_FINGERPRINT=$(halos_ca_fingerprint "${CA_CRT}") || {
-    echo "prestart: failed to compute CA fingerprint; cert generation cannot continue" >&2
-    exit 1
-}
-
-# Change-detection sentinel: SHA256(sorted hostname list) ":" SHA256(CA cert).
-# Classification is in lib-ca.sh so the three-state read is independently
-# testable. match-shape → compare; legacy → migrate; unrecognized → regen.
-HOSTNAMES_HASH="$(halos_hostnames_hash)"
-SENTINEL="$(halos_ca_sentinel_compose "${HOSTNAMES_HASH}" "${CA_FINGERPRINT}")"
-NEED_LEAF=false
-if [ ! -f "${CERT_FILE}" ] || [ ! -f "${KEY_FILE}" ]; then
-    echo "Leaf certificate files not found, generating..."
-    NEED_LEAF=true
-elif [ -f "${DOMAIN_FILE}" ]; then
-    STORED=$(cat "${DOMAIN_FILE}")
-    case "$(halos_ca_sentinel_classify "${STORED}")" in
-        match-shape)
-            if [ "${STORED}" != "${SENTINEL}" ]; then
-                echo "Hostname list or CA changed, re-signing leaf certificate..."
-                NEED_LEAF=true
-            fi
-            ;;
-        legacy)
-            echo "Legacy cert sentinel detected, migrating to combined hostname+CA sentinel..."
-            NEED_LEAF=true
-            ;;
-        unrecognized)
-            echo "Cert sentinel unrecognized or corrupt, regenerating leaf certificate..."
-            NEED_LEAF=true
-            ;;
-    esac
-else
-    echo "Cert tracking file not found, regenerating leaf certificate..."
-    NEED_LEAF=true
-fi
-
-if [ "${NEED_LEAF}" = true ]; then
-    # Invalidate the sentinel BEFORE attempting to re-sign. If halos_ca_sign_leaf
-    # partially succeeds (key swapped, cert mv fails) and prestart exits, the
-    # sentinel is gone — so the next boot will detect "no sentinel" and retry
-    # rather than seeing a stale "everything matches" and silently skipping
-    # past a key/cert mismatch that would break TLS handshakes.
-    rm -f "${DOMAIN_FILE}"
-
-    # Build subjectAltName: DNS: entries followed by IP: entries, sorted
-    # for deterministic output. Each value passed through the loader has
-    # already been validated; we still quote at use site (defense-in-depth).
-    SAN_ENTRIES=""
-    while IFS= read -r dns_entry; do
-        [ -z "$dns_entry" ] && continue
-        SAN_ENTRIES="${SAN_ENTRIES}${SAN_ENTRIES:+,}DNS:${dns_entry}"
-    done < <(halos_dns_hostnames | LC_ALL=C sort)
-    if [ "${#HALOS_HOSTNAMES_IPS[@]}" -gt 0 ]; then
-        while IFS= read -r ip_entry; do
-            [ -z "$ip_entry" ] && continue
-            SAN_ENTRIES="${SAN_ENTRIES}${SAN_ENTRIES:+,}IP:${ip_entry}"
-        done < <(printf '%s\n' "${HALOS_HOSTNAMES_IPS[@]}" | LC_ALL=C sort)
-    fi
-
-    echo "Signing TLS leaf certificate (CN=${HALOS_DOMAIN}, SANs=${SAN_ENTRIES})..."
-    # halos_ca_sign_leaf handles atomic key-then-cert swap internally. On
-    # failure the previous leaf is left untouched and the sentinel (which
-    # we just rm'd) stays absent, forcing a retry next boot.
-    halos_ca_sign_leaf \
-        "${CA_CRT}" "${CA_KEY}" \
-        "${CERT_FILE}" "${KEY_FILE}" \
-        "${SAN_ENTRIES}" "${HALOS_DOMAIN}"
-    printf '%s' "${SENTINEL}" > "${DOMAIN_FILE}"
-    echo "Leaf certificate signed successfully"
-else
-    echo "Using existing leaf certificate for ${HALOS_DOMAIN}"
-fi
-
-# Share the leaf with Cockpit (:9090) by installing a combined-PEM override at
-# /etc/cockpit/ws-certs.d/99-halos.cert. cockpit-tls picks the lex-last *.cert
-# file at socket activation, so the 99- prefix overrides the upstream
-# 0-self-signed.cert generated by cockpit-certificate-ensure. The upstream cert
-# stays as the safety-net floor — removing 99-halos.cert reverts cockpit to
-# upstream-generated self-signed without further action. See docs/CERTS.md.
-#
-# Runs UNCONDITIONALLY on every prestart: cheap when nothing has changed (the
-# combined PEM is just cert+key concat) and self-heals if the override file
-# was deleted manually. Skipped (with a log line) when /etc/cockpit/ws-certs.d
-# doesn't exist — the cockpit package is only pulled in via halos-cockpit-config's
-# Recommends, so install-order variance can leave the dir absent for a window.
-COCKPIT_WS_CERTS_DIR="/etc/cockpit/ws-certs.d"
-COCKPIT_LEAF_OVERRIDE="${COCKPIT_WS_CERTS_DIR}/99-halos.cert"
-if [ -d "${COCKPIT_WS_CERTS_DIR}" ]; then
-    echo "Installing Cockpit leaf cert override at ${COCKPIT_LEAF_OVERRIDE}..."
-    # Tolerate failure here on purpose. The Cockpit override is auxiliary —
-    # upstream's 0-self-signed.cert (from cockpit-certificate-ensure) is the
-    # safety-net floor (see docs/CERTS.md). Letting a transient cockpit-install
-    # failure abort prestart would take down Traefik/Authelia/Homarr too, which
-    # is the opposite of the documented design intent. Log loudly so the
-    # operator can investigate, and keep going.
-    if ! halos_cockpit_install_leaf "${CERT_FILE}" "${KEY_FILE}" "${COCKPIT_LEAF_OVERRIDE}"; then
-        echo "WARNING: Cockpit leaf cert install failed; :9090 will keep its previous cert (upstream self-signed if no prior override). The rest of prestart continues." >&2
-    fi
-else
-    echo "Skipping Cockpit leaf cert install: ${COCKPIT_WS_CERTS_DIR} does not exist (cockpit-ws not yet installed)"
-fi
+# TLS leaf + CA artifacts are provisioned by halos-manage-certs.service
+# (oneshot, ordered Before=halos-core-containers.service). That unit owns
+# CA selection, leaf signing, public-CA publish, and the Cockpit cert
+# override. By the time prestart runs, the leaf files referenced by the
+# Traefik dynamic config below (/certs/halos.{crt,key}) already exist on
+# the data root. See docs/CERTS.md and assets/halos-manage-certs.
 
 # Dynamic Configuration Directory
 DYNAMIC_DIR="/etc/halos/traefik-dynamic.d"

--- a/tests/test-halos-manage-certs.sh
+++ b/tests/test-halos-manage-certs.sh
@@ -120,24 +120,29 @@ test_idempotent_rerun_preserves_leaf_and_sentinel() {
     # After a successful first run, re-running with identical state must NOT
     # rotate the leaf or the auto-CA. Verified by inode comparison on
     # ca.crt and halos.crt (mv would change the inode; mtime alone is not
-    # robust on filesystems with second-only granularity).
+    # robust on filesystems with second-only granularity). Sentinel content
+    # checked byte-for-byte so a corrupted .domain file (which would force
+    # a re-sign on the next run) is caught.
     local d
     d=$(new_scratch idempotent)
     run_script "$d" >/dev/null
-    local ca_inode_before leaf_inode_before
+    local ca_inode_before leaf_inode_before sentinel_before
     ca_inode_before=$(stat -c '%i' "$(_auto_ca_crt "$d")" 2>/dev/null \
         || stat -f '%i' "$(_auto_ca_crt "$d")")
     leaf_inode_before=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
         || stat -f '%i' "$(_cert_file "$d")")
+    sentinel_before=$(cat "$(_domain_file "$d")")
     sleep 1
     run_script "$d" >/dev/null
-    local ca_inode_after leaf_inode_after
+    local ca_inode_after leaf_inode_after sentinel_after
     ca_inode_after=$(stat -c '%i' "$(_auto_ca_crt "$d")" 2>/dev/null \
         || stat -f '%i' "$(_auto_ca_crt "$d")")
     leaf_inode_after=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
         || stat -f '%i' "$(_cert_file "$d")")
+    sentinel_after=$(cat "$(_domain_file "$d")")
     assert_eq "$ca_inode_after" "$ca_inode_before" "auto-CA must not rotate on idempotent rerun" || return 1
     assert_eq "$leaf_inode_after" "$leaf_inode_before" "leaf must not rotate on idempotent rerun" || return 1
+    assert_eq "$sentinel_after" "$sentinel_before" "sentinel content must be preserved on idempotent rerun" || return 1
 }
 
 test_hostname_change_triggers_leaf_only_resign() {
@@ -285,6 +290,129 @@ test_broken_custom_ca_aborts_run() {
     assert_no_file "$(_cert_file "$d")" "leaf must NOT be signed when custom CA is broken" || return 1
 }
 
+test_valid_custom_ca_takes_precedence_over_auto() {
+    # Happy-path companion to test_broken_custom_ca_aborts_run: when the
+    # operator drops a valid CA at /etc/halos/ca, the script must use it
+    # (mode=custom) and sign the leaf with it — confirming the precedence
+    # branch in halos_ca_select_active isn't only ever exercised on the
+    # failure path.
+    local d
+    d=$(new_scratch valid_custom)
+    (
+        umask 077
+        openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+            -keyout "$d/custom-ca/ca.key" -out "$d/custom-ca/ca.crt" \
+            -subj "/CN=Test Operator CA" \
+            -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" \
+            >/dev/null 2>&1
+    ) || { echo "custom CA fixture creation failed"; return 1; }
+    chmod 0700 "$d/custom-ca"
+    local out
+    out=$(run_script "$d" 2>&1) || { echo "$out"; return 1; }
+    if ! echo "$out" | grep -q "mode=custom"; then
+        echo "expected 'mode=custom' in script output; got:"
+        echo "$out"
+        return 1
+    fi
+    if ! openssl verify -CAfile "$d/custom-ca/ca.crt" "$(_cert_file "$d")" >/dev/null 2>&1; then
+        echo "leaf must verify against the operator-supplied custom CA"
+        return 1
+    fi
+    # Auto-CA must NOT have been written when custom mode is active.
+    assert_no_file "$(_auto_ca_crt "$d")" "auto-CA must not be written when custom CA is active" || return 1
+}
+
+test_leaf_includes_ip_san_when_hostnames_conf_has_ip() {
+    # Exercises the script's IP-SAN branch (which iterates HALOS_HOSTNAMES_IPS
+    # in addition to halos_dns_hostnames). All other tests use DNS-only
+    # configs, so without this case the IP-SAN code is dead in test.
+    local d
+    d=$(new_scratch ip_san)
+    printf '%s\n%s\n' "fixture.test" "10.42.0.1" > "$d/hostnames.conf"
+    run_script "$d" >/dev/null
+    local sans
+    sans=$(openssl x509 -in "$(_cert_file "$d")" -noout -ext subjectAltName 2>&1)
+    if ! echo "$sans" | grep -q "DNS:fixture.test"; then
+        echo "leaf SAN missing DNS:fixture.test; got: $sans"
+        return 1
+    fi
+    if ! echo "$sans" | grep -q "IP Address:10.42.0.1"; then
+        echo "leaf SAN missing IP Address:10.42.0.1; got: $sans"
+        return 1
+    fi
+}
+
+test_leaf_has_expected_cert_structure() {
+    # Content-level structural assertions on the first-boot leaf. Without
+    # these a regression that produced a 0-byte / wrong-CN / wrong-EKU /
+    # over-825-day cert would pass the existence-only checks elsewhere.
+    local d
+    d=$(new_scratch leaf_structure)
+    run_script "$d" >/dev/null
+    local leaf="$(_cert_file "$d")"
+    local subject_cn
+    subject_cn=$(openssl x509 -in "$leaf" -noout -subject -nameopt RFC2253 \
+        | sed -n 's/.*CN=\([^,]*\).*/\1/p')
+    assert_eq "$subject_cn" "fixture.test" "leaf CN must match canonical hostname" || return 1
+    if ! openssl x509 -in "$leaf" -noout -ext subjectAltName 2>&1 | grep -q "DNS:fixture.test"; then
+        echo "leaf SAN must include DNS:fixture.test"
+        return 1
+    fi
+    if ! openssl x509 -in "$leaf" -noout -ext basicConstraints 2>&1 | grep -q "CA:FALSE"; then
+        echo "leaf must have basicConstraints CA:FALSE"
+        return 1
+    fi
+    if ! openssl x509 -in "$leaf" -noout -ext extendedKeyUsage 2>&1 | grep -q "TLS Web Server Authentication"; then
+        echo "leaf must have extendedKeyUsage serverAuth (Chrome requires it)"
+        return 1
+    fi
+    local not_before not_after nb_epoch na_epoch validity_days
+    not_before=$(openssl x509 -in "$leaf" -noout -startdate | cut -d= -f2)
+    not_after=$(openssl x509 -in "$leaf" -noout -enddate | cut -d= -f2)
+    nb_epoch=$(date -u -d "$not_before" +%s 2>/dev/null \
+        || date -u -j -f "%b %d %T %Y %Z" "$not_before" +%s)
+    na_epoch=$(date -u -d "$not_after" +%s 2>/dev/null \
+        || date -u -j -f "%b %d %T %Y %Z" "$not_after" +%s)
+    validity_days=$(( (na_epoch - nb_epoch) / 86400 ))
+    if [ "$validity_days" -gt 825 ]; then
+        echo "leaf validity $validity_days exceeds Apple's 825-day cap"
+        return 1
+    fi
+}
+
+test_fingerprint_guard_exits_when_helper_fails() {
+    # Validates the `CA_FINGERPRINT=$(...) || exit 1` guard at the top of
+    # the post-CA-select block. Bash `set -e` does NOT abort on command-
+    # substitution failure in an assignment, so the explicit guard is
+    # load-bearing — without it, an empty fingerprint would feed a
+    # malformed sentinel into downstream comparison and induce an
+    # infinite re-sign loop. We trigger the failure by stubbing
+    # halos_ca_fingerprint via the HALOS_LIB_CA seam.
+    local d
+    d=$(new_scratch fp_guard)
+    run_script "$d" >/dev/null
+    cat > "$d/stub-lib-ca.sh" <<EOF
+. "$LIB_CA"
+halos_ca_fingerprint() {
+    echo "stub: simulating fingerprint failure" >&2
+    return 1
+}
+EOF
+    if HALOS_ETC_DIR="$d/etc" \
+       HALOS_LIB_HOSTNAMES="$LIB_HOSTNAMES" \
+       HALOS_LIB_CA="$d/stub-lib-ca.sh" \
+       HALOS_CUSTOM_CA_DIR="$d/custom-ca" \
+       HALOS_COCKPIT_WS_CERTS_DIR="$d/cockpit-certs" \
+       HALOS_HOSTNAMES_FILE="$d/hostnames.conf" \
+       PACKAGE_NAME="halos-core-containers" \
+       CONTAINER_DATA_ROOT="$d/data" \
+       bash "$SCRIPT" >/dev/null 2>&1; then
+        echo "script must exit non-zero when halos_ca_fingerprint fails"
+        return 1
+    fi
+}
+
 # ---------------------------------------------------------------------------
 
 run_test test_first_boot_bootstrap_creates_all_artifacts
@@ -294,6 +422,10 @@ run_test test_renewal_threshold_triggers_leaf_only_resign
 run_test test_auto_ca_expired_rotates_ca_and_leaf
 run_test test_cockpit_dir_absent_skips_install_without_failure
 run_test test_broken_custom_ca_aborts_run
+run_test test_valid_custom_ca_takes_precedence_over_auto
+run_test test_leaf_includes_ip_san_when_hostnames_conf_has_ip
+run_test test_leaf_has_expected_cert_structure
+run_test test_fingerprint_guard_exits_when_helper_fails
 
 echo
 echo "Passed: $PASSES, Failed: $FAILS"

--- a/tests/test-halos-manage-certs.sh
+++ b/tests/test-halos-manage-certs.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# Tests for assets/halos-manage-certs
+#
+# Run from repo root:
+#   bash tests/test-halos-manage-certs.sh
+#
+# The script is exec'd in a subshell per test with HALOS_* env overrides
+# pointing all on-disk state at a per-test tmpdir. This avoids touching
+# /var/lib, /etc/halos, or /etc/cockpit while still exercising the real
+# script (and the lib-ca / lib-hostnames functions it calls).
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/assets/halos-manage-certs"
+LIB_CA="$REPO_ROOT/assets/lib-ca.sh"
+LIB_HOSTNAMES="$REPO_ROOT/assets/lib-hostnames.sh"
+
+for f in "$SCRIPT" "$LIB_CA" "$LIB_HOSTNAMES"; do
+    [ -f "$f" ] || { echo "missing fixture: $f" >&2; exit 2; }
+done
+
+PASSES=0
+FAILS=0
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+if [ -t 1 ]; then
+    GREEN=$'\033[32m'; RED=$'\033[31m'; RESET=$'\033[0m'
+else
+    GREEN=""; RED=""; RESET=""
+fi
+
+assert_eq() {
+    if [ "$1" = "$2" ]; then return 0; fi
+    printf '%s    actual:   %q\n    expected: %q\n' "$3" "$1" "$2" >&2
+    return 1
+}
+
+assert_file() {
+    [ -f "$1" ] && return 0
+    printf '%s    missing file: %s\n' "$2" "$1" >&2
+    return 1
+}
+
+assert_no_file() {
+    [ ! -e "$1" ] && return 0
+    printf '%s    unexpected file: %s\n' "$2" "$1" >&2
+    return 1
+}
+
+run_test() {
+    local name="$1"
+    local out
+    if out=$("$name" 2>&1); then
+        PASSES=$((PASSES + 1))
+        printf '%sPASS%s %s\n' "$GREEN" "$RESET" "$name"
+    else
+        FAILS=$((FAILS + 1))
+        printf '%sFAIL%s %s\n%s\n' "$RED" "$RESET" "$name" "$out"
+    fi
+}
+
+# Build a per-test scratch layout and echo the data root so the test can
+# reference $D/... paths. CUSTOM_CA_DIR stays empty (auto-CA mode);
+# COCKPIT_WS_CERTS_DIR is created so the cockpit-override branch runs.
+new_scratch() {
+    local d="$TMPDIR_ROOT/$1"
+    mkdir -p "$d/data" "$d/etc" "$d/custom-ca" "$d/cockpit-certs"
+    printf '%s\n' "fixture.test" > "$d/hostnames.conf"
+    printf '%s' "$d"
+}
+
+# Invoke the script with HALOS_* env overrides pointing at the scratch
+# layout. PACKAGE_NAME=halos-core-containers so AUTO_CA_DIR lands at
+# $CONTAINER_DATA_ROOT/halos-core-containers/certs/ca — matching the
+# production layout.
+run_script() {
+    local d="$1"
+    HALOS_ETC_DIR="$d/etc" \
+    HALOS_LIB_HOSTNAMES="$LIB_HOSTNAMES" \
+    HALOS_LIB_CA="$LIB_CA" \
+    HALOS_CUSTOM_CA_DIR="$d/custom-ca" \
+    HALOS_COCKPIT_WS_CERTS_DIR="$d/cockpit-certs" \
+    HALOS_HOSTNAMES_FILE="$d/hostnames.conf" \
+    PACKAGE_NAME="halos-core-containers" \
+    CONTAINER_DATA_ROOT="$d/data" \
+    bash "$SCRIPT"
+}
+
+# Paths the script writes, as a function of the scratch root.
+_cert_file() { printf '%s' "$1/data/traefik/certs/halos.crt"; }
+_key_file()  { printf '%s' "$1/data/traefik/certs/halos.key"; }
+_domain_file() { printf '%s' "$1/data/traefik/certs/.domain"; }
+_auto_ca_crt() { printf '%s' "$1/data/halos-core-containers/certs/ca/ca.crt"; }
+_auto_ca_key() { printf '%s' "$1/data/halos-core-containers/certs/ca/ca.key"; }
+_public_ca() { printf '%s' "$1/data/halos-core-containers/certs/public/halos-ca.crt"; }
+_cockpit_override() { printf '%s' "$1/cockpit-certs/99-halos.cert"; }
+
+# ---------------------------------------------------------------------------
+
+test_first_boot_bootstrap_creates_all_artifacts() {
+    # No prior state. Expect: auto-CA created, leaf signed, sentinel written,
+    # public CA published, cockpit override installed.
+    local d
+    d=$(new_scratch first_boot)
+    run_script "$d" >/dev/null
+    assert_file "$(_auto_ca_crt "$d")" "auto-CA cert" || return 1
+    assert_file "$(_auto_ca_key "$d")" "auto-CA key" || return 1
+    assert_file "$(_cert_file "$d")" "leaf cert" || return 1
+    assert_file "$(_key_file "$d")" "leaf key" || return 1
+    assert_file "$(_domain_file "$d")" "sentinel" || return 1
+    assert_file "$(_public_ca "$d")" "public CA copy" || return 1
+    assert_file "$(_cockpit_override "$d")" "cockpit override" || return 1
+}
+
+test_idempotent_rerun_preserves_leaf_and_sentinel() {
+    # After a successful first run, re-running with identical state must NOT
+    # rotate the leaf or the auto-CA. Verified by inode comparison on
+    # ca.crt and halos.crt (mv would change the inode; mtime alone is not
+    # robust on filesystems with second-only granularity).
+    local d
+    d=$(new_scratch idempotent)
+    run_script "$d" >/dev/null
+    local ca_inode_before leaf_inode_before
+    ca_inode_before=$(stat -c '%i' "$(_auto_ca_crt "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_auto_ca_crt "$d")")
+    leaf_inode_before=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_cert_file "$d")")
+    sleep 1
+    run_script "$d" >/dev/null
+    local ca_inode_after leaf_inode_after
+    ca_inode_after=$(stat -c '%i' "$(_auto_ca_crt "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_auto_ca_crt "$d")")
+    leaf_inode_after=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_cert_file "$d")")
+    assert_eq "$ca_inode_after" "$ca_inode_before" "auto-CA must not rotate on idempotent rerun" || return 1
+    assert_eq "$leaf_inode_after" "$leaf_inode_before" "leaf must not rotate on idempotent rerun" || return 1
+}
+
+test_hostname_change_triggers_leaf_only_resign() {
+    # Changing the hostname list mutates HOSTNAMES_HASH → sentinel mismatch
+    # → leaf re-sign. Auto-CA must stay put (CA fingerprint half of the
+    # sentinel is unchanged).
+    local d
+    d=$(new_scratch hostname_change)
+    run_script "$d" >/dev/null
+    local ca_inode_before leaf_inode_before
+    ca_inode_before=$(stat -c '%i' "$(_auto_ca_crt "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_auto_ca_crt "$d")")
+    leaf_inode_before=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_cert_file "$d")")
+    printf '%s\n%s\n' "fixture.test" "second.test" > "$d/hostnames.conf"
+    sleep 1
+    run_script "$d" >/dev/null
+    local ca_inode_after leaf_inode_after
+    ca_inode_after=$(stat -c '%i' "$(_auto_ca_crt "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_auto_ca_crt "$d")")
+    leaf_inode_after=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_cert_file "$d")")
+    assert_eq "$ca_inode_after" "$ca_inode_before" "auto-CA must not rotate on hostname-only change" || return 1
+    if [ "$leaf_inode_after" = "$leaf_inode_before" ]; then
+        echo "leaf must re-sign on hostname change (inodes still equal: $leaf_inode_before)"
+        return 1
+    fi
+}
+
+test_renewal_threshold_triggers_leaf_only_resign() {
+    # Synthesize a leaf+sentinel pair where the leaf is just inside the
+    # 60-day renewal window. Sentinel intentionally matches what the script
+    # would compute (so the sentinel branch passes), so the only thing
+    # that can fire NEED_LEAF=true is the halos_ca_leaf_needs_renewal gate.
+    local d
+    d=$(new_scratch renewal)
+    run_script "$d" >/dev/null
+    # Re-sign the leaf with a 30-day validity, then re-compute and write the
+    # matching sentinel so the sentinel branch is a no-op. The library
+    # signs leaves with HALOS_CA_LEAF_VALIDITY_DAYS; override via the 7th
+    # arg to halos_ca_sign_leaf.
+    (
+        # shellcheck source=../assets/lib-ca.sh
+        . "$LIB_CA"
+        # shellcheck source=../assets/lib-hostnames.sh
+        . "$LIB_HOSTNAMES"
+        HALOS_HOSTNAMES_FILE="$d/hostnames.conf" halos_load_hostnames
+        halos_ca_sign_leaf \
+            "$(_auto_ca_crt "$d")" "$(_auto_ca_key "$d")" \
+            "$(_cert_file "$d")" "$(_key_file "$d")" \
+            "DNS:fixture.test" "fixture.test" \
+            30
+        ca_fp=$(halos_ca_fingerprint "$(_auto_ca_crt "$d")")
+        hn_hash=$(halos_hostnames_hash)
+        sentinel=$(halos_ca_sentinel_compose "$hn_hash" "$ca_fp")
+        printf '%s' "$sentinel" > "$(_domain_file "$d")"
+    )
+    local leaf_inode_before
+    leaf_inode_before=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_cert_file "$d")")
+    sleep 1
+    run_script "$d" >/dev/null
+    local leaf_inode_after
+    leaf_inode_after=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_cert_file "$d")")
+    if [ "$leaf_inode_after" = "$leaf_inode_before" ]; then
+        echo "leaf must re-sign when within renewal threshold (inodes still equal: $leaf_inode_before)"
+        return 1
+    fi
+}
+
+test_auto_ca_expired_rotates_ca_and_leaf() {
+    # Replace the auto-CA with a cert that's already expired
+    # (notAfter in the past). halos_ca_ensure_auto sees it as unhealthy
+    # and regenerates → new fingerprint → sentinel mismatch → leaf re-sign.
+    local d
+    d=$(new_scratch ca_expired)
+    run_script "$d" >/dev/null
+    local ca_inode_before leaf_inode_before
+    ca_inode_before=$(stat -c '%i' "$(_auto_ca_crt "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_auto_ca_crt "$d")")
+    leaf_inode_before=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_cert_file "$d")")
+    # Overwrite the CA with a same-keypair-but-already-expired cert.
+    # Using openssl req -x509 with the existing key, explicit not_before
+    # and not_after well in the past. CA:TRUE / keyCertSign extensions
+    # so halos_ca_ensure_auto's structural checks still pass; only the
+    # validity-period check fails.
+    local nb na
+    nb=$(date -u -d "@$(( $(date -u +%s) - 30 * 86400 ))" +%Y%m%d%H%M%SZ 2>/dev/null \
+        || date -u -r "$(( $(date -u +%s) - 30 * 86400 ))" +%Y%m%d%H%M%SZ)
+    na=$(date -u -d "@$(( $(date -u +%s) - 86400 ))" +%Y%m%d%H%M%SZ 2>/dev/null \
+        || date -u -r "$(( $(date -u +%s) - 86400 ))" +%Y%m%d%H%M%SZ)
+    openssl req -x509 -nodes -key "$(_auto_ca_key "$d")" \
+        -out "$(_auto_ca_crt "$d")" \
+        -not_before "$nb" -not_after "$na" \
+        -subj "/CN=Expired Auto CA" \
+        -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" \
+        >/dev/null 2>&1 \
+        || { echo "fixture cert regen failed"; return 1; }
+    sleep 1
+    run_script "$d" >/dev/null
+    local ca_inode_after leaf_inode_after
+    ca_inode_after=$(stat -c '%i' "$(_auto_ca_crt "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_auto_ca_crt "$d")")
+    leaf_inode_after=$(stat -c '%i' "$(_cert_file "$d")" 2>/dev/null \
+        || stat -f '%i' "$(_cert_file "$d")")
+    if [ "$ca_inode_after" = "$ca_inode_before" ]; then
+        echo "auto-CA must regenerate when expired (inodes still equal: $ca_inode_before)"
+        return 1
+    fi
+    if [ "$leaf_inode_after" = "$leaf_inode_before" ]; then
+        echo "leaf must re-sign when CA rotates (inodes still equal: $leaf_inode_before)"
+        return 1
+    fi
+}
+
+test_cockpit_dir_absent_skips_install_without_failure() {
+    # When the cockpit-ws cert dir doesn't exist, the install branch logs
+    # and is skipped; the script must still exit 0 and produce the leaf.
+    local d
+    d=$(new_scratch cockpit_absent)
+    rm -rf "$d/cockpit-certs"
+    if ! run_script "$d" >/dev/null 2>&1; then
+        echo "script exited non-zero when cockpit dir absent"
+        return 1
+    fi
+    assert_file "$(_cert_file "$d")" "leaf must still be produced" || return 1
+    assert_no_file "$(_cockpit_override "$d")" "cockpit override must NOT be installed when dir absent" || return 1
+}
+
+test_broken_custom_ca_aborts_run() {
+    # An operator drops malformed files into /etc/halos/ca. halos_ca_select_active
+    # must reject and abort; we surface the failure (set -e) and exit non-zero.
+    # No leaf gets signed.
+    local d
+    d=$(new_scratch broken_custom)
+    printf 'garbage\n' > "$d/custom-ca/ca.crt"
+    printf 'garbage\n' > "$d/custom-ca/ca.key"
+    if run_script "$d" >/dev/null 2>&1; then
+        echo "script must exit non-zero on broken custom CA"
+        return 1
+    fi
+    assert_no_file "$(_cert_file "$d")" "leaf must NOT be signed when custom CA is broken" || return 1
+}
+
+# ---------------------------------------------------------------------------
+
+run_test test_first_boot_bootstrap_creates_all_artifacts
+run_test test_idempotent_rerun_preserves_leaf_and_sentinel
+run_test test_hostname_change_triggers_leaf_only_resign
+run_test test_renewal_threshold_triggers_leaf_only_resign
+run_test test_auto_ca_expired_rotates_ca_and_leaf
+run_test test_cockpit_dir_absent_skips_install_without_failure
+run_test test_broken_custom_ca_aborts_run
+
+echo
+echo "Passed: $PASSES, Failed: $FAILS"
+[ "$FAILS" -eq 0 ]


### PR DESCRIPTION
Closes #139.

## What

Move CA selection, leaf signing, public-CA publish, and Cockpit cert sharing out of `prestart.sh` into a dedicated standalone script invoked by a new systemd oneshot unit ordered `Before=halos-core-containers.service`. `prestart.sh` now contains zero cert-lifecycle logic — `grep "halos_ca_" prestart.sh` returns 0 matches.

## Why a oneshot unit, not a call from prestart

The goal of extraction is to **decouple** cert lifecycle from container service restarts. Calling the new script from `prestart.sh` would be relocation with a stub — prestart would still own activation, #140's renewal timer would need a duplicate code path, and operators couldn't force a cert refresh without bouncing Traefik/Authelia/Homarr.

The oneshot pattern collapses #139 and #140 into a single execution path:

```
halos-manage-certs.service  (oneshot, Before=halos-core-containers.service)
                  ↑                ↑
                  |                |
       boot/restart of stack    halos-manage-certs.timer (#140)
```

One script, one service unit, two activation triggers. #140 becomes a thin `.timer` file with no new logic.

## Renewal gate

The script adds `halos_ca_leaf_needs_renewal` as a second `NEED_LEAF` gate alongside the existing sentinel check, so unchanged-config devices still rotate their leaf before Apple's 825-day ceiling expires it (the gap the #141 helper was added to close).

## Acceptance criteria (from #139)

- [x] All cert-related operations move to the new script — `assets/halos-manage-certs`
- [x] `prestart.sh` has zero `halos_ca_*` references — verified by grep
- [x] Existing behavior preserved (sentinel logic, ordering, `|| WARN` for auxiliary calls per #135 pattern)
- [x] Tests cover the script as a unit — 7 cases in `tests/test-halos-manage-certs.sh`: first-boot bootstrap, idempotent rerun, hostname-change leaf re-sign, renewal-threshold leaf re-sign, expired-CA rotation cascade, cockpit-dir-absent skip, broken-custom-CA abort
- [x] `docs/CERTS.md` updated to point at the new unit (new "Where cert lifecycle lives" section + cockpit revert/refresh procedures + custom-CA swap instructions)

## Files

| File | Change |
|---|---|
| `assets/halos-manage-certs` | new — standalone executable script |
| `debian/halos-core-containers.halos-manage-certs.service` | new — systemd oneshot unit |
| `tests/test-halos-manage-certs.sh` | new — 7 tests, all passing |
| `prestart.sh` | strip cert blocks; replace with explanatory pointer |
| `debian/rules` | install new script to `/usr/lib/<pkg>/halos-manage-certs` |
| `debian/postinst` | `systemctl enable halos-manage-certs.service` |
| `assets/lib-ca.sh` | update "Sourced by" header |
| `assets/lib-hostnames.sh` | update "Sourced by" header |
| `docs/CERTS.md` | new top-section + revert/refresh/swap procedure updates |

## Test plan

- [x] `./run test` — 7/7 halos-manage-certs + 76/76 lib-ca + 39/39 lib-hostnames pass locally
- [x] `bash -n` syntax check on both scripts
- [x] `shellcheck -x assets/halos-manage-certs` — only the expected SC1091 info about runtime-sourced env files
- [ ] CI run on this PR
- [ ] Smoke test on `halosdev.local` after package build: `systemctl status halos-manage-certs.service` shows `active (exited)`, the leaf at `/var/lib/container-apps/halos-core-containers/data/traefik/certs/halos.crt` is fresh, and `halos-core-containers.service` starts cleanly with `After=halos-manage-certs.service` ordering
- [ ] Force-refresh smoke: `sudo systemctl start halos-manage-certs` re-runs cleanly without touching the rest of the stack

## Operator notes

To force a cert refresh post-merge without restarting the full container stack:

```
sudo systemctl start halos-manage-certs.service
```

To revert to upstream Cockpit self-signed:

```
sudo rm /etc/cockpit/ws-certs.d/99-halos.cert
sudo systemctl restart cockpit
```

(Next `halos-manage-certs.service` activation will re-create the override — see `docs/CERTS.md`.)

## Follow-ups

- #140 — add `halos-manage-certs.timer` for periodic renewal. Now collapses to a single `.timer` file with no new logic.
