### PR TITLE
fix(packaging): install halos-manage-certs.{service,timer} via --name=

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -64,21 +64,13 @@ EOF
             # Reload systemd to recognize new service
             systemctl daemon-reload
 
-            # Enable services. halos-manage-certs.service has
-            # WantedBy=halos-core-containers.service in [Install], so
-            # enabling it drops a wants/ symlink that pulls it in
-            # automatically whenever the container stack activates.
-            # halos-manage-certs.timer periodically re-fires the service
-            # so long-running devices renew their leaf before Apple's
-            # 825-day SSL ceiling expires it.
+            # halos-manage-certs.{service,timer} are enabled and started
+            # by #DEBHELPER# below via dh_installsystemd --name= in
+            # debian/rules. The service's WantedBy=halos-core-containers
+            # .service pulls it in whenever the stack activates; the
+            # timer renews the leaf on a 24h cadence to stay under
+            # Apple's 825-day SSL ceiling.
             systemctl enable ${PKG_NAME}.service || true
-            systemctl enable halos-manage-certs.service || true
-            systemctl enable halos-manage-certs.timer || true
-            # Start the timer immediately so an upgrade on a long-uptime
-            # device doesn't wait for the next reboot to begin its
-            # 24h-cadence renewal schedule. Safe to call even if the
-            # timer is already running.
-            systemctl start halos-manage-certs.timer || true
         fi
         ;;
 esac

--- a/debian/rules
+++ b/debian/rules
@@ -72,4 +72,12 @@ override_dh_auto_install:
 override_dh_auto_test:
 	# Skip tests - validated manually
 
-# dh_installsystemd handles service file installation from debian/halos-core-containers.service
+# dh_installsystemd handles service file installation from debian/halos-core-containers.service.
+# Additional unit files (multiple service/timer for the same binary package) require
+# explicit --name= invocations — dh_installsystemd's autodetect only picks up
+# debian/<pkg>.<extension>, NOT debian/<pkg>.<name>.<extension>. Without the
+# --name=halos-manage-certs call below, debian/halos-core-containers.halos-manage-certs.{service,timer}
+# would be present in the source tree but silently absent from the built .deb.
+override_dh_installsystemd:
+	dh_installsystemd
+	dh_installsystemd --name=halos-manage-certs


### PR DESCRIPTION
## What broke

#142 and #143 added `debian/halos-core-containers.halos-manage-certs.service` and `.timer` to the source tree, expecting `dh_installsystemd` to pick them up automatically. It doesn't: that tool's auto-detection only handles `debian/<pkg>.<extension>` (one file per extension per binary package), NOT `debian/<pkg>.<name>.<extension>`. Multi-service files for the same binary package need an explicit `dh_installsystemd --name=<name>` invocation.

Result: since #142 merged this morning, every published `.deb` has shipped the `halos-manage-certs` script at `/usr/lib/halos-core-containers/halos-manage-certs` but neither the service nor the timer unit. Confirmed on `halosdev.local` post-upgrade to 0.3.4-7:

```
$ dpkg -L halos-core-containers | grep -E 'systemd|halos-manage'
/usr/lib/halos-core-containers/halos-manage-certs
/usr/lib/systemd
/usr/lib/systemd/system
/usr/lib/systemd/system/halos-core-containers.service
```

No `halos-manage-certs.service`, no `halos-manage-certs.timer`. The activation chain from #142 (Requires= + After= on halos-core-containers.service) and the renewal timer from #143 are both completely inoperative. The package upgrades cleanly, but devices remain on the pre-#141 10-year-validity leaf that Apple rejects.

## Fix

Override `dh_installsystemd` in `debian/rules` to invoke it twice — once for the default (`halos-core-containers.service`) and once with `--name=halos-manage-certs` which picks up both `.service` and `.timer` for that name. Verified locally:

```
$ docker run --rm -v "$(pwd):/workspace" debian:trixie bash -c \
    "dpkg-deb -c /workspace/build/halos-core-containers_*_all.deb | grep systemd"
drwxr-xr-x root/root         0 ./usr/lib/systemd/
drwxr-xr-x root/root         0 ./usr/lib/systemd/system/
-rw-r--r-- root/root       704 ./usr/lib/systemd/system/halos-core-containers.service
-rw-r--r-- root/root       912 ./usr/lib/systemd/system/halos-manage-certs.service
-rw-r--r-- root/root      1312 ./usr/lib/systemd/system/halos-manage-certs.timer
```

## Test plan

- [x] Local build via `./run build` succeeds
- [x] `dpkg-deb -c` on the built .deb shows all three unit files
- [ ] CI green
- [ ] Apt pipeline publishes new version
- [ ] `apt upgrade` on `halosdev.local`; `dpkg -L halos-core-containers | grep manage-certs` shows the unit files; `systemctl status halos-manage-certs.service` shows `active (exited)`; `systemctl list-timers halos-manage-certs.timer` shows the next fire; `openssl x509 -in /var/lib/container-apps/halos-core-containers/data/traefik/certs/halos.crt -noout -enddate` shows ≤824-day validity

## Severity

This regression has been live since #142 merged at 08:27 UTC today, affecting every device that upgraded to 0.3.4-7 or later. The blast radius is "renewal mechanism doesn't run" — pre-existing certs continue working (until their natural expiry), but the whole cert-lifecycle umbrella (#141 + #139 + #140) has been delivering zero functionality to upgraded devices.

## Follow-up

Should add packaging-validation to CI: `dpkg-deb -c build/*.deb | grep -q halos-manage-certs.service` post-build, fail if missing. Out of scope for this hotfix.
