### PR TITLE
fix(packaging): avoid literal #DEBHELPER# token in postinst comment

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -65,11 +65,12 @@ EOF
             systemctl daemon-reload
 
             # halos-manage-certs.{service,timer} are enabled and started
-            # by #DEBHELPER# below via dh_installsystemd --name= in
-            # debian/rules. The service's WantedBy=halos-core-containers
-            # .service pulls it in whenever the stack activates; the
-            # timer renews the leaf on a 24h cadence to stay under
-            # Apple's 825-day SSL ceiling.
+            # by debhelper snippets appended below (see
+            # dh_installsystemd --name= in debian/rules). The service's
+            # WantedBy=halos-core-containers.service pulls it in
+            # whenever the stack activates; the timer renews the leaf
+            # on a 24h cadence to stay under Apple's 825-day SSL
+            # ceiling.
             systemctl enable ${PKG_NAME}.service || true
         fi
         ;;


### PR DESCRIPTION
## What broke

#145 added a comment in `debian/postinst` pointing future readers at the auto-generated maintainer-script snippets:

```
# halos-manage-certs.{service,timer} are enabled and started
# by #DEBHELPER# below via dh_installsystemd --name= in
# ...
```

`dh_installsystemd` does naive string substitution on `#DEBHELPER#` regardless of context — so the token inside the comment got replaced with the full multi-line enable/start blocks for `halos-manage-certs.{service,timer}`. That broke the comment's leading `#` from the rest of the source line, leaving the word `below` as a bareword command at the top level of the script.

`postinst` exits 127 on every configure of 0.3.4-8:

```
Setting up halos-core-containers (0.3.4-8) ...
Created symlink '/etc/systemd/system/halos-core-containers.service.wants/halos-manage-certs.service' → ...
Created symlink '/etc/systemd/system/timers.target.wants/halos-manage-certs.timer' → ...
/var/lib/dpkg/info/halos-core-containers.postinst: 145: below: not found
dpkg: error processing package halos-core-containers (--configure):
 installed halos-core-containers package post-installation script subprocess returned error exit status 127
```

Unit files **do** install correctly because `dh_installsystemd` emits the symlinks before the broken line executes — but the package is left in the half-configured `iF` state until reconfigure succeeds. Containers themselves are unaffected; the renewal timer doesn't run from this device because configure never completes.

## Fix

Rewrite the comment to refer to "debhelper snippets appended below" without the literal token. One-line change in the comment block.

## Test plan

- [x] \`./run build\` succeeds
- [x] \`sh -n\` on the extracted postinst from the rebuilt \`.deb\` exits clean
- [x] On \`halosdev.local\` after dropping the rebuilt postinst into \`/var/lib/dpkg/info/halos-core-containers.postinst\` and running \`sudo dpkg --configure halos-core-containers\`:
  - \`dpkg -l halos-core-containers\` shows \`ii\` (not \`iF\`)
  - \`halos-manage-certs.service\` runs to completion (\`status=0/SUCCESS\`)
  - \`systemctl list-timers halos-manage-certs.timer\` shows next fire in ~24h
- [ ] CI green
- [ ] APT pipeline publishes new version
- [ ] \`apt upgrade halos-core-containers\` on \`halosdev.local\` reconfigures cleanly

## Severity

Same blast radius as #144: every device that upgrades to 0.3.4-8 hits a postinst failure. Devices stay on the previously-running container stack but \`dpkg --configure -a\` until reconfigured. New devices flashing 0.3.4-8 will report \`installed-failed\` after install. This needs to land and publish before any wider deployment.

## Follow-up

Worth a \`docs/solutions/\` entry: never use the literal token \`#DEBHELPER#\` inside Debian maintainer-script comments, because \`dh_installsystemd\`/\`dh_installinit\`/\`dh_installdebconf\` etc. perform unconditional string substitution.