### PR TITLE
fix(certs): touch Traefik dynamic config on leaf rotation

### DIFF
--- a/assets/halos-manage-certs
+++ b/assets/halos-manage-certs
@@ -277,7 +277,11 @@ fi
 if [ "${NEED_LEAF}" = true ]; then
     if [ -f "${TRAEFIK_TLS_CONFIG}" ]; then
         echo "Leaf rotated; touching Traefik dynamic config to reload certs at ${TRAEFIK_TLS_CONFIG}..."
-        if ! touch "${TRAEFIK_TLS_CONFIG}"; then
+        # -c (no-create): if the file is removed in the narrow window between
+        # the existence check above and the touch, do NOT create an empty
+        # placeholder Traefik can't parse. The check + -c together make the
+        # path strictly mtime-only.
+        if ! touch -c "${TRAEFIK_TLS_CONFIG}"; then
             echo "WARNING: touch ${TRAEFIK_TLS_CONFIG} failed; Traefik will keep serving the previous leaf until the next halos-core-containers.service restart." >&2
         fi
     else

--- a/assets/halos-manage-certs
+++ b/assets/halos-manage-certs
@@ -21,6 +21,7 @@
 #   HALOS_LIB_CA               /usr/lib/<pkg>/lib-ca.sh
 #   HALOS_CUSTOM_CA_DIR        /etc/halos/ca
 #   HALOS_COCKPIT_WS_CERTS_DIR /etc/cockpit/ws-certs.d
+#   HALOS_TRAEFIK_DYNAMIC_DIR  /etc/halos/traefik-dynamic.d
 
 set -e
 
@@ -84,6 +85,8 @@ DOMAIN_FILE="${CERTS_DIR}/.domain"
 PUBLIC_CA_DIR="${CONTAINER_DATA_ROOT}/${PACKAGE_NAME}/certs/public"
 COCKPIT_WS_CERTS_DIR="${HALOS_COCKPIT_WS_CERTS_DIR:-/etc/cockpit/ws-certs.d}"
 COCKPIT_LEAF_OVERRIDE="${COCKPIT_WS_CERTS_DIR}/99-halos.cert"
+TRAEFIK_DYNAMIC_DIR="${HALOS_TRAEFIK_DYNAMIC_DIR:-/etc/halos/traefik-dynamic.d}"
+TRAEFIK_TLS_CONFIG="${TRAEFIK_DYNAMIC_DIR}/tls-default.yml"
 
 mkdir -p "${CERTS_DIR}"
 
@@ -244,6 +247,41 @@ if [ "${NEED_LEAF}" = true ] && [ "${COCKPIT_INSTALL_SUCCEEDED}" = true ]; then
         fi
     else
         echo "Skipping cockpit.socket reload: systemd not running"
+    fi
+fi
+
+# Traefik (:443) reads halos.crt/halos.key via its file-provider dynamic
+# config at ${TRAEFIK_TLS_CONFIG}. Its file watcher fires on changes to
+# the dynamic-config FILE but does NOT watch the referenced cert files,
+# so a fresh leaf on disk is ignored until the YAML is touched. Bump the
+# YAML's mtime to force Traefik to re-evaluate the dynamic config, which
+# re-reads the cert from disk — see traefik/traefik#5495 for the
+# upstream limitation.
+#
+# Why not SIGHUP: PR traefik/traefik#9993 (v3.0.0) intended SIGHUP for
+# file-provider reload, but issue traefik/traefik#11624 reports SIGHUP
+# *kills* Traefik on the v3.x line (confirmed on 3.3.3, unfixed at the
+# time of writing). Touch is the safe path; SIGHUP would silently take
+# the proxy down on every rotation.
+#
+# Gated on NEED_LEAF=true so a no-op timer fire doesn't churn Traefik's
+# config every 24h. On first boot the dynamic-config file doesn't yet
+# exist (halos-manage-certs.service runs Before= halos-core-containers,
+# which is what generates the file via prestart.sh); the missing-file
+# branch logs and skips because Traefik isn't running yet and will load
+# the freshly-signed leaf on its first start.
+#
+# The "Leaf rotated; touching Traefik dynamic config to reload certs"
+# log line is the test signal — assertable without depending on a real
+# Traefik container.
+if [ "${NEED_LEAF}" = true ]; then
+    if [ -f "${TRAEFIK_TLS_CONFIG}" ]; then
+        echo "Leaf rotated; touching Traefik dynamic config to reload certs at ${TRAEFIK_TLS_CONFIG}..."
+        if ! touch "${TRAEFIK_TLS_CONFIG}"; then
+            echo "WARNING: touch ${TRAEFIK_TLS_CONFIG} failed; Traefik will keep serving the previous leaf until the next halos-core-containers.service restart." >&2
+        fi
+    else
+        echo "Skipping Traefik cert reload: ${TRAEFIK_TLS_CONFIG} does not exist (halos-core-containers prestart will generate it on next start)"
     fi
 fi
 

--- a/prestart.sh
+++ b/prestart.sh
@@ -74,7 +74,14 @@ DYNAMIC_DIR="/etc/halos/traefik-dynamic.d"
 DYNAMIC_SRC_DIR="${SCRIPT_DIR}/assets/traefik/dynamic"
 mkdir -p "${DYNAMIC_DIR}"
 
-# Generate dynamic TLS configuration
+# Generate dynamic TLS configuration.
+#
+# IMPORTANT: assets/halos-manage-certs hardcodes the filename "tls-default.yml"
+# in TRAEFIK_TLS_CONFIG and touches it on leaf rotation to force Traefik's
+# file-watcher to re-read the cert. Renaming this file requires updating that
+# script as well, or rotation-driven cert reload silently falls into the
+# "Skipping Traefik cert reload" branch and Traefik keeps serving the stale
+# leaf until the next halos-core-containers.service restart.
 TLS_CONFIG_FILE="${DYNAMIC_DIR}/tls-default.yml"
 cat > "${TLS_CONFIG_FILE}" << EOF
 # Default TLS certificate configuration

--- a/tests/test-halos-manage-certs.sh
+++ b/tests/test-halos-manage-certs.sh
@@ -68,9 +68,24 @@ run_test() {
 # COCKPIT_WS_CERTS_DIR is created so the cockpit-override branch runs.
 new_scratch() {
     local d="$TMPDIR_ROOT/$1"
-    mkdir -p "$d/data" "$d/etc" "$d/custom-ca" "$d/cockpit-certs"
+    mkdir -p "$d/data" "$d/etc" "$d/custom-ca" "$d/cockpit-certs" "$d/traefik-dynamic"
     printf '%s\n' "fixture.test" > "$d/hostnames.conf"
     printf '%s' "$d"
+}
+
+# Synthesize the Traefik dynamic config file that prestart.sh would have
+# created when halos-core-containers.service starts. Production wiring:
+# the halos-manage-certs touch branch is gated on the file existing, so
+# tests that exercise the "touch fired" path need this preplaced.
+_seed_traefik_tls_config() {
+    cat > "$1/traefik-dynamic/tls-default.yml" <<'EOF'
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /certs/halos.crt
+        keyFile: /certs/halos.key
+EOF
 }
 
 # Invoke the script with HALOS_* env overrides pointing at the scratch
@@ -84,6 +99,7 @@ run_script() {
     HALOS_LIB_CA="$LIB_CA" \
     HALOS_CUSTOM_CA_DIR="$d/custom-ca" \
     HALOS_COCKPIT_WS_CERTS_DIR="$d/cockpit-certs" \
+    HALOS_TRAEFIK_DYNAMIC_DIR="$d/traefik-dynamic" \
     HALOS_HOSTNAMES_FILE="$d/hostnames.conf" \
     PACKAGE_NAME="halos-core-containers" \
     CONTAINER_DATA_ROOT="$d/data" \
@@ -98,6 +114,7 @@ _auto_ca_crt() { printf '%s' "$1/data/halos-core-containers/certs/ca/ca.crt"; }
 _auto_ca_key() { printf '%s' "$1/data/halos-core-containers/certs/ca/ca.key"; }
 _public_ca() { printf '%s' "$1/data/halos-core-containers/certs/public/halos-ca.crt"; }
 _cockpit_override() { printf '%s' "$1/cockpit-certs/99-halos.cert"; }
+_traefik_tls_config() { printf '%s' "$1/traefik-dynamic/tls-default.yml"; }
 
 # ---------------------------------------------------------------------------
 
@@ -525,6 +542,134 @@ test_cockpit_reload_signal_emitted_on_renewal_threshold_resign() {
     fi
 }
 
+test_traefik_reload_touch_fires_on_leaf_change() {
+    # When the leaf is re-signed AND the Traefik dynamic config file
+    # already exists (i.e., halos-core-containers has run prestart.sh
+    # at least once), halos-manage-certs touches the YAML to force
+    # Traefik's file watcher to re-read the cert. The "touching Traefik
+    # dynamic config" log line is the assertable signal; mtime change
+    # is verified via `-nt` against a fixed sentinel (portable across
+    # GNU and BSD `stat`).
+    local d
+    d=$(new_scratch traefik_reload_on_change)
+    _seed_traefik_tls_config "$d"
+    # Backdate the config to "2020-01-01" and place a "2024-01-01"
+    # sentinel between that and "now". A successful touch advances the
+    # config to the wall clock, making config newer than sentinel.
+    touch -t 202001010000 "$(_traefik_tls_config "$d")"
+    touch -t 202401010000 "$d/mtime-sentinel"
+    local out
+    out=$(run_script "$d" 2>&1) || { echo "$out"; return 1; }
+    if ! echo "$out" | grep -q "touching Traefik dynamic config to reload certs"; then
+        echo "expected Traefik-reload signal on first-boot leaf signing; got:"
+        echo "$out"
+        return 1
+    fi
+    if [ ! "$(_traefik_tls_config "$d")" -nt "$d/mtime-sentinel" ]; then
+        echo "expected tls-default.yml mtime to advance past mtime-sentinel after touch"
+        return 1
+    fi
+}
+
+test_traefik_reload_skipped_on_idempotent_rerun() {
+    # The touch must NOT fire when the leaf wasn't rotated. Without
+    # this gate, the timer would re-touch the dynamic config every 24h,
+    # causing pointless reload churn in Traefik.
+    local d
+    d=$(new_scratch traefik_reload_idempotent)
+    _seed_traefik_tls_config "$d"
+    run_script "$d" >/dev/null
+    # Backdate to "2020-01-01" after first run; sentinel at "2024-01-01".
+    # On idempotent rerun the touch must NOT fire, so the config stays
+    # at 2020 and remains older than the sentinel.
+    touch -t 202001010000 "$(_traefik_tls_config "$d")"
+    touch -t 202401010000 "$d/mtime-sentinel"
+    local out
+    out=$(run_script "$d" 2>&1) || { echo "$out"; return 1; }
+    if echo "$out" | grep -q "touching Traefik dynamic config to reload certs"; then
+        echo "Traefik-reload touch must NOT fire on idempotent rerun; got:"
+        echo "$out"
+        return 1
+    fi
+    if [ "$(_traefik_tls_config "$d")" -nt "$d/mtime-sentinel" ]; then
+        echo "tls-default.yml mtime must not advance on idempotent rerun"
+        return 1
+    fi
+}
+
+test_traefik_reload_skipped_when_dynamic_config_absent() {
+    # First-boot path: halos-manage-certs runs Before= halos-core-containers,
+    # so on initial provisioning the dynamic config file doesn't exist yet.
+    # halos-core-containers prestart.sh will create it with the freshly-signed
+    # leaf already on disk, so no reload is needed (Traefik hasn't started).
+    # The script must log a skip line rather than touching a non-existent
+    # file (which would create an empty placeholder Traefik can't parse).
+    local d
+    d=$(new_scratch traefik_reload_no_config)
+    rm -rf "$d/traefik-dynamic"
+    local out
+    out=$(run_script "$d" 2>&1) || { echo "$out"; return 1; }
+    if echo "$out" | grep -q "touching Traefik dynamic config to reload certs"; then
+        echo "Traefik-reload touch must NOT fire when dynamic config absent; got:"
+        echo "$out"
+        return 1
+    fi
+    if ! echo "$out" | grep -q "Skipping Traefik cert reload"; then
+        echo "expected 'Skipping Traefik cert reload' log line on first-boot path; got:"
+        echo "$out"
+        return 1
+    fi
+    if [ -e "$(_traefik_tls_config "$d")" ]; then
+        echo "tls-default.yml must NOT be created by halos-manage-certs (prestart.sh owns that file)"
+        return 1
+    fi
+}
+
+test_traefik_reload_fires_on_renewal_threshold_resign() {
+    # Renewal-driven re-sign path: synthesize a near-expiry leaf with
+    # matching sentinel so only the renewal gate sets NEED_LEAF=true,
+    # confirming the touch is wired to NEED_LEAF (not specifically to
+    # the sentinel-mismatch branch).
+    local d
+    d=$(new_scratch traefik_reload_renewal)
+    _seed_traefik_tls_config "$d"
+    run_script "$d" >/dev/null
+    (
+        # shellcheck source=../assets/lib-ca.sh
+        . "$LIB_CA"
+        # shellcheck source=../assets/lib-hostnames.sh
+        . "$LIB_HOSTNAMES"
+        HALOS_HOSTNAMES_FILE="$d/hostnames.conf" halos_load_hostnames
+        halos_ca_sign_leaf \
+            "$(_auto_ca_crt "$d")" "$(_auto_ca_key "$d")" \
+            "$(_cert_file "$d")" "$(_key_file "$d")" \
+            "DNS:fixture.test" "fixture.test" \
+            30
+        ca_fp=$(halos_ca_fingerprint "$(_auto_ca_crt "$d")")
+        hn_hash=$(halos_hostnames_hash)
+        sentinel=$(halos_ca_sentinel_compose "$hn_hash" "$ca_fp")
+        printf '%s' "$sentinel" > "$(_domain_file "$d")"
+    )
+    touch -t 202001010000 "$(_traefik_tls_config "$d")"
+    touch -t 202401010000 "$d/mtime-sentinel"
+    local out
+    out=$(run_script "$d" 2>&1) || { echo "$out"; return 1; }
+    if ! echo "$out" | grep -q "touching Traefik dynamic config to reload certs"; then
+        echo "expected Traefik-reload signal on renewal-threshold re-sign; got:"
+        echo "$out"
+        return 1
+    fi
+    if ! echo "$out" | grep -q "within renewal threshold"; then
+        echo "expected 'within renewal threshold' log line (renewal-gate branch); got:"
+        echo "$out"
+        return 1
+    fi
+    if [ ! "$(_traefik_tls_config "$d")" -nt "$d/mtime-sentinel" ]; then
+        echo "expected tls-default.yml mtime to advance past mtime-sentinel after renewal-driven touch"
+        return 1
+    fi
+}
+
 test_fingerprint_guard_exits_when_helper_fails() {
     # Validates the `CA_FINGERPRINT=$(...) || exit 1` guard at the top of
     # the post-CA-select block. Bash `set -e` does NOT abort on command-
@@ -574,6 +719,10 @@ run_test test_cockpit_reload_signal_skipped_on_idempotent_rerun
 run_test test_cockpit_reload_signal_skipped_when_cockpit_dir_absent
 run_test test_cockpit_reload_signal_skipped_when_install_fails
 run_test test_cockpit_reload_signal_emitted_on_renewal_threshold_resign
+run_test test_traefik_reload_touch_fires_on_leaf_change
+run_test test_traefik_reload_skipped_on_idempotent_rerun
+run_test test_traefik_reload_skipped_when_dynamic_config_absent
+run_test test_traefik_reload_fires_on_renewal_threshold_resign
 run_test test_fingerprint_guard_exits_when_helper_fails
 
 echo

--- a/tests/test-halos-manage-certs.sh
+++ b/tests/test-halos-manage-certs.sh
@@ -77,6 +77,11 @@ new_scratch() {
 # created when halos-core-containers.service starts. Production wiring:
 # the halos-manage-certs touch branch is gated on the file existing, so
 # tests that exercise the "touch fired" path need this preplaced.
+#
+# The YAML body below is illustrative — halos-manage-certs only calls
+# `touch -c` on this file, never parses it. The body kept in sync with
+# prestart.sh's actual output is documentation, not a contract: a future
+# rewrite that empties the file would not affect any of these tests.
 _seed_traefik_tls_config() {
     cat > "$1/traefik-dynamic/tls-default.yml" <<'EOF'
 tls:
@@ -479,6 +484,7 @@ EOF
         HALOS_LIB_CA="$d/stub-lib-ca.sh" \
         HALOS_CUSTOM_CA_DIR="$d/custom-ca" \
         HALOS_COCKPIT_WS_CERTS_DIR="$d/cockpit-certs" \
+        HALOS_TRAEFIK_DYNAMIC_DIR="$d/traefik-dynamic" \
         HALOS_HOSTNAMES_FILE="$d/hostnames.conf" \
         PACKAGE_NAME="halos-core-containers" \
         CONTAINER_DATA_ROOT="$d/data" \
@@ -561,7 +567,7 @@ test_traefik_reload_touch_fires_on_leaf_change() {
     local out
     out=$(run_script "$d" 2>&1) || { echo "$out"; return 1; }
     if ! echo "$out" | grep -q "touching Traefik dynamic config to reload certs"; then
-        echo "expected Traefik-reload signal on first-boot leaf signing; got:"
+        echo "expected Traefik-reload signal on initial leaf signing with pre-existing dynamic config; got:"
         echo "$out"
         return 1
     fi
@@ -693,6 +699,7 @@ EOF
        HALOS_LIB_CA="$d/stub-lib-ca.sh" \
        HALOS_CUSTOM_CA_DIR="$d/custom-ca" \
        HALOS_COCKPIT_WS_CERTS_DIR="$d/cockpit-certs" \
+       HALOS_TRAEFIK_DYNAMIC_DIR="$d/traefik-dynamic" \
        HALOS_HOSTNAMES_FILE="$d/hostnames.conf" \
        PACKAGE_NAME="halos-core-containers" \
        CONTAINER_DATA_ROOT="$d/data" \


### PR DESCRIPTION
## Summary

After `halos-manage-certs` rotates the device leaf, Traefik kept serving the previous cert in-memory until `halos-core-containers.service` was restarted. The script already signals `cockpit.socket` to reload but did nothing equivalent for Traefik — the asymmetry called out in #147. On long-uptime devices this defeats the renewal pipeline's purpose on the device's primary entrypoint (`:443`).

Traefik watches its **dynamic-config file** via inotify but does **not** watch the cert files referenced from `defaultCertificate.certFile`/`keyFile` ([traefik/traefik#5495](https://github.com/traefik/traefik/issues/5495)). Touching the YAML forces Traefik to re-evaluate the dynamic config, which re-reads the cert from disk — no container restart, no connection drop.

## Why not SIGHUP (Option A in the issue)

The issue suggested SIGHUP as the preferred approach. I investigated and found this is **unsafe** on the v3.x line:

- [traefik/traefik#9993](https://github.com/traefik/traefik/pull/9993) added SIGHUP file-provider reload in v3.0.0.
- [traefik/traefik#11624](https://github.com/traefik/traefik/issues/11624) reports that SIGHUP **kills** Traefik on the v3.x line (confirmed on 3.3.3, unfixed at filing).
- Sending SIGHUP on every rotation would silently take `:443` down.

The touch-the-config-file approach is the documented Traefik pattern and is what the upstream community recommends for exactly this case. Inline comments in the script cite both upstream tickets.

## Behaviour

The new block mirrors the cockpit-reload block's gating:

| Path | Behaviour |
|------|-----------|
| `NEED_LEAF=true`, tls-default.yml exists | `touch` the YAML, log `Leaf rotated; touching Traefik dynamic config to reload certs ...` |
| `NEED_LEAF=true`, file missing (first boot) | Skip with log: `Skipping Traefik cert reload: ... does not exist (halos-core-containers prestart will generate it on next start)` — `halos-manage-certs.service` runs `Before=` `halos-core-containers.service`, so on first provisioning Traefik isn't running yet and will load the fresh leaf on its first start |
| `NEED_LEAF=false` (idempotent timer fire) | No touch — prevents 24h churn |
| `touch` itself fails (read-only FS etc) | WARN, don't abort (cert management has completed) |

## Tests

`tests/test-halos-manage-certs.sh` gains 4 cases that mirror the cockpit-reload battery:

- `test_traefik_reload_touch_fires_on_leaf_change` — first-run signing fires touch, mtime advances past sentinel
- `test_traefik_reload_skipped_on_idempotent_rerun` — second run with no changes does NOT touch
- `test_traefik_reload_skipped_when_dynamic_config_absent` — first-boot path: skip log, no file created
- `test_traefik_reload_fires_on_renewal_threshold_resign` — renewal-gate triggers reload (regression guard if someone gates touch on the sentinel branch only)

mtime assertions use `[ file -nt sentinel ]` instead of `stat -c '%Y'` so the suite runs on BSD `stat` (macOS dev) and GNU `stat` (CI) without divergence.

All 20 `test-halos-manage-certs.sh` tests pass; full repo `./run test` green (76 + 39 + 20 cases across lib-ca, lib-hostnames, halos-manage-certs).

## Reproduction & verification

Issue #147's reproduction steps:

\`\`\`
sudo rm /var/lib/container-apps/halos-core-containers/data/traefik/certs/halos.{crt,key}
sudo systemctl start halos-manage-certs.service
echo | openssl s_client -servername halosdev.local -connect halosdev.local:443 2>/dev/null \
  | openssl x509 -noout -dates
\`\`\`

Before this PR: dates unchanged until \`systemctl restart halos-core-containers.service\`.
After this PR (per test coverage + Traefik's documented watch behaviour): dates advance within the file-watcher's debounce window.

I have **not** smoke-tested this on \`halosdev.local\` (deploying the updated script to a shared device required permission I didn't have in this session). The unit tests fully cover the new branches and the upstream behaviour is well-documented. Happy to wire up a one-shot device smoke test on request — script swap + the repro above is trivial once the deb is built and deployed via the normal CI/CD pipeline.

## Out of scope (and intentionally so, per issue)

- Re-issuance gating (already correct, #141)
- Cockpit reload (already wired in this script)
- Pre-#141 long-validity leaf force-renewal mechanism — this PR is what makes the documented one-shot operator action (\`rm halos.{crt,key}\` + \`systemctl start halos-manage-certs.service\`) actually take effect on \`:443\` without a stack restart

Closes #147

## Test plan

- [x] \`./run test\` — all suites green locally
- [ ] CI passes
- [ ] Device smoke test against \`halosdev.local\` after CI/CD pipeline deploys the new \`.deb\` (operator-triggered repro per the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)