### PR TITLE
fix(homarr): preserve originating host on post-login redirect (part of #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ without an extra warning.
 ### Canonical hostname
 
 The first non-IP entry is **canonical**. The OIDC issuer URL (the `iss`
-claim, the discovery endpoint, NextAuth's `NEXTAUTH_URL`) always points
-to the canonical host. OIDC login on a non-canonical hostname briefly
-visits canonical for the Authelia UI, then returns to the originating
-host. The canonical host must be reachable from the user's network for
-OIDC login to succeed.
+claim, the discovery endpoint, `AUTH_OIDC_ISSUER`) always points to the
+canonical host. Every other URL — including Homarr's NextAuth callback
+and post-login redirect — is built per request from `x-forwarded-host`,
+so OIDC login on a non-canonical hostname briefly visits canonical for
+the Authelia UI, then returns to the originating host. The canonical
+host must be reachable from the user's network for OIDC login to
+succeed.
 
 ### Cross-paradigm SSO trade-off
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,8 +116,13 @@ services:
       - "${HALOS_DOMAIN}:host-gateway"
     environment:
       - SECRET_ENCRYPTION_KEY=${SECRET_ENCRYPTION_KEY}
-      # Tell NextAuth the canonical HTTPS URL (behind Traefik proxy)
-      - NEXTAUTH_URL=https://${HALOS_DOMAIN}
+      # NEXTAUTH_URL is intentionally unset. With trustHost: true in the
+      # Homarr fork's NextAuth config, the request's x-forwarded-host /
+      # x-forwarded-proto determine the base URL per request. Setting
+      # NEXTAUTH_URL forces next-auth's reqWithEnvURL() to override the
+      # inbound Host with this canonical value, breaking multi-hostname
+      # access — every post-login redirect lands on canonical regardless
+      # of the originating host.
       # SECURITY: Disables TLS verification for ALL Node.js HTTPS requests.
       # Required for self-signed Traefik certs. Acceptable for local-only device.
       - NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/docs/solutions/2026-05-27-nextauth-url-canonical-host-leak.md
+++ b/docs/solutions/2026-05-27-nextauth-url-canonical-host-leak.md
@@ -1,0 +1,35 @@
+---
+title: "NEXTAUTH_URL forces canonical Host on every NextAuth redirect, defeating multi-hostname access"
+date: 2026-05-27
+repo: halos-core-containers
+issue: https://github.com/halos-org/halos/issues/117
+tags: [homarr, nextauth, authjs, multi-host, sso, oidc, reverse-proxy]
+---
+
+# Problem
+
+After multi-hostname support shipped (Traefik path-only routing, per-host Authelia cookies, per-host OIDC redirect_uris, Homarr fork with header-driven URL construction), browsing Homarr on a non-canonical hostname and logging in still teleported the user to the canonical hostname (`${hostname}.local`). The OIDC issuer hop to canonical is expected (single-issuer constraint); the post-login redirect back to the originating host is not.
+
+Symptom: every redirect generated server-side by NextAuth used the canonical Host regardless of the request's `x-forwarded-host`.
+
+# Root Cause
+
+`docker-compose.yml` set `NEXTAUTH_URL=https://${HALOS_DOMAIN}` (canonical). Two next-auth code paths consume that env var and override request-driven URL construction:
+
+1. `next-auth/lib/env.js` `reqWithEnvURL(req)` rewrites the request URL's origin to match `AUTH_URL ?? NEXTAUTH_URL` before any handler logic runs. Called from `next-auth/index.js` on every GET/POST to the `/api/auth/*` route, and from `lib/index.js` `handleAuth` for middleware-style auth.
+
+2. `@auth/core/lib/utils/env.js` `createActionURL(...)` prefers `AUTH_URL ?? NEXTAUTH_URL` over `x-forwarded-host`/`host` headers when constructing internal URLs (session endpoints, signin URLs, callback URLs). Used by `getSession` for server-side `auth()` calls in RSCs.
+
+The Homarr fork's `reqWithTrustedOrigin(req)` rewrite in `apps/nextjs/src/app/api/auth/[...nextauth]/route.ts` correctly substitutes `x-forwarded-host`/`x-forwarded-proto` into the request URL before passing it to NextAuth, but `reqWithEnvURL` is called next inside NextAuth's own handler and silently undoes that work whenever the env var is set. Setting `trustHost: true` in the NextAuth config (which Homarr does) is necessary but not sufficient — `trustHost` controls validation, not URL construction precedence.
+
+# Solution
+
+Unset `NEXTAUTH_URL` (and `AUTH_URL`). With `trustHost: true`, NextAuth derives the base URL from the request headers per call, which is exactly what multi-hostname access requires. The Homarr fork's per-request OIDC `redirect_uri` and `redirectProxyUrl` (both built from headers via `createRedirectUri`) then function as designed, and `createActionURL` falls through to the `x-forwarded-host` branch.
+
+The OIDC issuer URL is still pinned to canonical via `AUTH_OIDC_ISSUER=https://${HALOS_DOMAIN}/sso`, satisfying the single-issuer constraint without leaking canonical into post-auth redirects. The container's `extra_hosts: "${HALOS_DOMAIN}:host-gateway"` entry stays — Homarr's server-side OIDC discovery call still resolves the issuer hostname.
+
+# Lessons
+
+- For NextAuth/Auth.js v5 behind a reverse proxy serving multiple hostnames, `NEXTAUTH_URL` and `AUTH_URL` must remain unset. `trustHost: true` alone is not enough; the env URL overrides take precedence over request headers in two separate code paths.
+- The fork's per-request URL rewriter (`reqWithTrustedOrigin`) is necessary because Next.js's `NextRequest.nextUrl.origin` reflects the container-internal listen address, not the public Host. With `NEXTAUTH_URL` unset, that rewriter is what makes header-driven URL construction work end-to-end.
+- Future regression test: any new env var that next-auth or `@auth/core` reads with `AUTH_*` / `NEXTAUTH_*` naming is potential for the same class of bug. Grep `node_modules/next-auth` for `process.env.AUTH_` references when upgrading next-auth or auth.js.


### PR DESCRIPTION
## Summary

Removes `NEXTAUTH_URL=https://${HALOS_DOMAIN}` from the Homarr container in `docker-compose.yml`. With `trustHost: true` in the Homarr fork's NextAuth config and the per-request `reqWithTrustedOrigin` rewriter active in the fork's `[...nextauth]/route.ts`, NextAuth derives URLs from `x-forwarded-host` per request — which is exactly what multi-hostname access requires.

The OIDC issuer remains canonical via `AUTH_OIDC_ISSUER` (single-issuer constraint, R11 in the multi-hostname design).

## Root cause

Two next-auth code paths consume `AUTH_URL`/`NEXTAUTH_URL` and override request-driven URL construction even when `trustHost: true`:

1. `next-auth/lib/env.js` `reqWithEnvURL(req)` — rewrites the request URL's origin to the env URL origin *before any handler logic runs*. Called from `next-auth/index.js` on every GET/POST to `/api/auth/*`, and from `lib/index.js` `handleAuth` for middleware-style auth.
2. `@auth/core/lib/utils/env.js` `createActionURL(...)` — prefers `AUTH_URL ?? NEXTAUTH_URL` over `x-forwarded-host`/`host` headers when constructing internal URLs (session, signin, callback). Used by `getSession` for server-side `auth()` calls in RSCs.

Result: the Homarr fork's `reqWithTrustedOrigin` rewrite (header → request URL) was silently undone inside NextAuth, and every server-generated redirect landed on canonical regardless of the originating host.

## Why this is the minimal fix

- `trustHost: true` was already set in the fork — it controls host *validation*, not URL construction precedence
- The fork already builds OIDC `redirect_uri` and `redirectProxyUrl` from request headers (`createRedirectUri`)
- The only thing forcing canonical was the env override; removing it lets the existing fork machinery work as designed
- `extra_hosts: "${HALOS_DOMAIN}:host-gateway"` stays — Homarr's server-side OIDC discovery still needs to resolve the canonical issuer host
- `AUTH_OIDC_ISSUER` stays pointed at canonical — single-issuer constraint is intentional

## Test plan

- [x] `./run test` — 39/39 shell-library tests pass locally
- [ ] On a test device with a non-canonical hostname added to `/etc/halos/hostnames.conf`, log in via Homarr on the non-canonical host; verify post-login lands back on the originating host (not canonical)
- [ ] Verify canonical login still works (regression check)
- [ ] Verify `auth()` calls in RSCs return correct session data when accessed via non-canonical host
- [ ] CI green

## Docs

- `README.md` "Canonical hostname" section updated to reflect that only the OIDC issuer is canonical; all other URLs are header-driven
- `docs/solutions/2026-05-27-nextauth-url-canonical-host-leak.md` added: captures the two next-auth code paths and why `trustHost: true` alone wasn't enough

## Scope

This PR addresses the **root cause** sub-task from halos-org/halos#117 ("Audit `NEXTAUTH_URL`"). Other sub-tasks in that issue — refreshing the local brainstorm/plan docs, deciding on `hatlabs/homarr#4`, tracking upstream PR #5595, etc. — are out of scope here; they can be tackled separately once this fix is verified on a test device.

Refs halos-org/halos#117 (this PR addresses one of several sub-tasks; the canonical-reachability-over-VPN docs gap stays open under that issue, see halos-org/docs#15).
