### PR TITLE
docs(agents): release-notes guidance for canonical-hostname-affecting changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ Core container application definitions for HaLOS. These apps are pre-installed i
 
 **Link issues and PRs:** Always link related GitHub issues in PR descriptions with `Closes #<issue-number>`. When a single tracking issue spans multiple PRs (umbrella issue with implementation units), use `Refs #<issue-number>` on the unit PRs and `Closes #<issue-number>` only on the final unit so the umbrella stays open until the work is genuinely complete.
 
+**Release-notes call-outs.** Some changes invalidate existing Authelia/OIDC sessions or break cached id_tokens in ways that aren't obvious from the diff. When a PR changes canonical-hostname semantics, `hostnames.conf` defaults, or Authelia/OIDC client registration, name the user-visible upgrade consequences under a "Release notes" heading in the PR description so the changelog catches them.
+
 ## Version Management
 
 This repository uses the same versioning system as halos-marine-containers:


### PR DESCRIPTION
## Summary

Adds a short release-notes reminder to AGENTS.md under the Git Workflow Policy heading. When a PR changes canonical-hostname semantics, `hostnames.conf` defaults, or Authelia/OIDC client registration, the author should name the user-visible upgrade consequences (invalidated sessions, broken cached id_tokens, etc.) under a "Release notes" heading in the PR description so the changelog catches them.

Kept terse — this is a reminder, not a reference document. Specific failure modes per surface live in the brainstorm/architecture docs where they belong.

## Test plan

- [x] No code changes; doc-only.
- [ ] CI green (this PR is excluded from version-bump-check as a docs-only change per the `*.md` exclusion in `shared-workflows/.github/workflows/version-bump-check.yml`).

Closes #153