### PR TITLE
ci: use shared pr-checks workflow (wires in version-bump-check)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,11 +5,9 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run tests
-        uses: ./.github/actions/run-tests
+  checks:
+    uses: halos-org/shared-workflows/.github/workflows/pr-checks.yml@main
+    with:
+      # Skip lintian in PR checks - container-packaging-tools ensures compliance.
+      # Lintian runs as a backstop in build-release.yml before publishing.
+      skip-lintian: true


### PR DESCRIPTION
## Why

This repo's \`.github/workflows/pr.yml\` only ran tests; it never called \`shared-workflows/.github/workflows/version-bump-check.yml\`. That gap let #151 land a runtime-behavior change to \`docker-compose.yml\` without bumping \`VERSION\`, producing the semantically-wrong \`v0.4.0+2\` tag. #154 fixed the VERSION after the fact, but the right time to catch it is at PR-check time.

## What

Replaces the inline test-only \`pr.yml\` with a call to the shared \`pr-checks.yml\` reusable workflow — same pattern halos-marine-containers already uses. That orchestrator runs:

1. Tests via this repo's existing \`.github/actions/run-tests\`
2. Version-bump-check from shared-workflows (the new coverage)
3. Lintian — **skipped here** (\`skip-lintian: true\`) because lintian runs as a backstop in \`build-release.yml\` before publishing, same rationale as halos-marine-containers

## Required companion

halos-org/shared-workflows#25 — stops \`version-bump-check.yml\` from silently excluding root \`docker-compose.yml\`. Without that PR, this wiring catches future cases where any other package-affecting file changes without a VERSION bump, but the specific compose-only regression that motivated all this still slips through. Both PRs should land together.

## Test plan

- [ ] CI green (the new shared workflow runs against this PR — the diff touches only \`.github/\` so version-bump-check is excluded; tests still run)
- [ ] After merge: future PRs touching package-affecting files without a VERSION bump fail PR Checks rather than landing silently