### PR TITLE
feat(routing): proxy SK Server icons on :443

### DIFF
--- a/assets/traefik/dynamic/signalk-server-icons.yml
+++ b/assets/traefik/dynamic/signalk-server-icons.yml
@@ -1,0 +1,37 @@
+# Serve Signal K Server static icons / images same-origin on :443 instead
+# of redirecting them to the per-app port :4430, so the dashboard's cert
+# exception covers them and the user avoids a per-port click-through.
+# Full rationale (browser cert-exception model, scope trade-offs):
+# docs/CERTS.md → "Same-origin asset serving on :443".
+http:
+  routers:
+    signalk-server-icons-on-443:
+      # Images only (case-insensitive); navigation (HTML/JS/CSS) intentionally
+      # falls through so plugin SPAs keep a `/`-rooted origin. See docs/CERTS.md.
+      rule: 'PathRegexp(`(?i)^/signalk-server/.+\.(svg|png|ico|jpg|jpeg|gif|avif|webp)$`)'
+      entrypoints:
+        - websecure
+      tls: {}
+      # Must beat the auto-generated redirect-signalk-server-https router (100).
+      priority: 200
+      middlewares:
+        - signalk-server-icons-strip-prefix
+        - strip-hsts@file  # don't re-introduce the HSTS leak the per-app routers strip
+      service: signalk-server-icons-backend
+
+  middlewares:
+    signalk-server-icons-strip-prefix:
+      stripPrefix:
+        prefixes:
+          - "/signalk-server"
+
+  services:
+    signalk-server-icons-backend:
+      loadBalancer:
+        servers:
+          # Backend host:port must track the Signal K Server app definition
+          # (halos-marine-containers/apps/signalk-server/metadata.yaml:
+          # `routing.host_port`, currently 3000) — the same target the
+          # auto-generated per-app `:4430` router derives from routing.d.
+          # This file hardcodes it; if the port ever changes, update both.
+          - url: "http://host.docker.internal:3000"

--- a/docs/CERTS.md
+++ b/docs/CERTS.md
@@ -278,3 +278,44 @@ sudo systemctl start halos-manage-certs.service
 The auto-CA at `/var/lib/container-apps/halos-core-containers/data/halos-core-containers/certs/ca/ca.crt`
 is preserved across mode switches; reverting just re-points
 `serving-ca.crt` back at it and re-signs the leaf with the auto-CA.
+
+## Same-origin asset serving on :443 (cert-exception friction)
+
+Until a device's CA is installed, every TLS surface the user touches needs a
+manual cert exception. Browsers key those exceptions by **`(host, port)`**
+(Chromium also folds in the leaf fingerprint; Safari is per-`(host, port)`
+even against the prior self-signed default). So each distinct port a user is
+sent to costs one more click-through, and multi-hostname access
+(`<host>.local` *and* the DHCP-domain FQDN) multiplies the count again.
+
+This bites the Homarr dashboard. Each Signal K plugin card renders an icon
+via a path-only URL such as
+`/signalk-server/@signalk/app-dock/app-icon.svg`. By default that path
+matches the auto-generated `redirect-signalk-server-https@file` router
+(priority 100, `PathPrefix(/signalk-server/)`) and gets 307-redirected to
+`https://<host>:4430/...` — the per-app port. Crossing from `:443` to
+`:4430` is a new `(host, port)` pair, so the dashboard renders with broken
+icons until the user manually visits `:4430` and clicks through the warning,
+once per app port they ever encounter.
+
+**Fix:** static images are not navigation and don't need origin isolation
+from the dashboard. `assets/traefik/dynamic/signalk-server-icons.yml`
+defines a higher-priority (200) router that catches image extensions under
+`/signalk-server/`, strips the prefix, and proxies them to the Signal K
+backend on `:443` directly. Served same-origin with the dashboard, they're
+covered by the cert exception the user already granted for the dashboard —
+no extra click-through.
+
+**Why only images.** The scope is deliberately narrow (svg, png, ico, jpg,
+jpeg, gif, avif, webp, case-insensitive). HTML, JS, and CSS are excluded: a
+Signal K plugin SPA loaded under a `/signalk-server/...` prefix on the
+dashboard origin would silently break, because webapps assume `/` as their
+root and embed absolute paths. Navigation to a plugin therefore stays on the
+existing redirect-to-`:4430` path so each plugin keeps a clean `/`-rooted
+origin — accepting the one cert exception per app port for *navigation*
+while eliminating it for *icons*. (The proper long-term fix is to install
+the device CA; see the CA download endpoint above. This router only removes
+the friction for the icon case in the meantime.)
+
+The router also wires `strip-hsts@file` so it does not re-introduce the HSTS
+leak the per-app routers were patched to strip.

--- a/tests/test-traefik-signalk-icons-regex.sh
+++ b/tests/test-traefik-signalk-icons-regex.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Tests for the PathRegexp rule in
+# assets/traefik/dynamic/signalk-server-icons.yml
+#
+# Run from repo root:
+#   bash tests/test-traefik-signalk-icons-regex.sh
+#
+# The rule decides which /signalk-server/* requests are served same-origin
+# on :443 (static images) versus left to the priority-100 redirect router
+# (navigation: HTML/JS/CSS). A regression here silently reproduces the
+# cross-port cert-exception friction the router exists to remove, with no
+# on-device signal. This test extracts the regex from the config itself so
+# it stays coupled to the shipped rule, and evaluates it the way Traefik
+# does: against the URL path only (query/fragment already stripped).
+#
+# Pure bash (POSIX ERE via [[ =~ ]]) to match the rest of the suite and
+# avoid any external-tool dependency in CI. The rule's `(?i)` flag (which
+# ERE does not interpret) is asserted separately, and case-insensitive
+# matching is emulated by lowercasing the path before matching against the
+# all-lowercase extension alternation — equivalent for this pattern.
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG="$REPO_ROOT/assets/traefik/dynamic/signalk-server-icons.yml"
+
+if [ ! -f "$CONFIG" ]; then
+    echo "config not found at $CONFIG" >&2
+    exit 2
+fi
+
+# Colors only when stdout is a TTY.
+if [ -t 1 ]; then
+    GREEN=$'\033[32m'; RED=$'\033[31m'; RESET=$'\033[0m'
+else
+    GREEN=""; RED=""; RESET=""
+fi
+
+PASSES=0
+FAILS=0
+
+# Pull the pattern out of `rule: 'PathRegexp(`<regex>`)'` — the regex is the
+# text between the backticks. Extracting from the file (not hardcoding it)
+# means this test guards the actual shipped rule.
+REGEX="$(sed -n "s/.*PathRegexp(\`\(.*\)\`).*/\1/p" "$CONFIG")"
+if [ -z "$REGEX" ]; then
+    echo "could not extract PathRegexp from $CONFIG" >&2
+    exit 2
+fi
+
+# ERE for [[ =~ ]]: strip the Go-RE2 `(?i)` inline flag (ERE can't parse it);
+# case-insensitivity is handled by lowercasing the candidate path below.
+ERE_REGEX="${REGEX#'(?i)'}"
+
+# regex_matches <path> -> exit 0 if the rule matches the path, 1 otherwise.
+regex_matches() {
+    local lower
+    lower="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+    [[ "$lower" =~ $ERE_REGEX ]]
+}
+
+assert_match() {
+    if regex_matches "$1"; then return 0; fi
+    printf '    expected MATCH (serve on :443) but did not: %q\n' "$1" >&2
+    return 1
+}
+
+assert_no_match() {
+    if ! regex_matches "$1"; then return 0; fi
+    printf '    expected NO match (redirect to :4430) but matched: %q\n' "$1" >&2
+    return 1
+}
+
+run_test() {
+    local name="$1"; local out
+    if out=$("$name" 2>&1); then
+        PASSES=$((PASSES + 1))
+        printf '%sPASS%s %s\n' "$GREEN" "$RESET" "$name"
+    else
+        FAILS=$((FAILS + 1))
+        printf '%sFAIL%s %s\n%s\n' "$RED" "$RESET" "$name" "$out"
+    fi
+}
+
+# --- The case-insensitive contract is in the rule itself --------------------
+
+test_rule_carries_case_insensitive_flag() {
+    case "$REGEX" in
+        '(?i)'*) return 0 ;;
+        *) printf '    rule must start with the (?i) flag; got: %q\n' "$REGEX" >&2; return 1 ;;
+    esac
+}
+
+# --- Should be served on :443 (static images) -------------------------------
+
+test_canonical_homarr_icon_path() {
+    assert_match "/signalk-server/@signalk/app-dock/app-icon.svg"
+}
+
+test_each_lowercase_extension() {
+    assert_match "/signalk-server/icon.svg" || return 1
+    assert_match "/signalk-server/icon.png" || return 1
+    assert_match "/signalk-server/favicon.ico" || return 1
+    assert_match "/signalk-server/photo.jpg" || return 1
+    assert_match "/signalk-server/image.webp"
+}
+
+test_jpeg_gif_avif_extensions() {
+    # .jpeg (not just .jpg), .gif, and .avif are real icon formats; missing
+    # them sends those icons back through the cert-friction redirect.
+    assert_match "/signalk-server/photo.jpeg" || return 1
+    assert_match "/signalk-server/anim.gif" || return 1
+    assert_match "/signalk-server/next.avif"
+}
+
+test_uppercase_extensions_match() {
+    # Case-insensitive: a plugin shipping APP-ICON.SVG must not regress.
+    assert_match "/signalk-server/@signalk/app-dock/APP-ICON.SVG" || return 1
+    assert_match "/signalk-server/Icon.PNG" || return 1
+    assert_match "/signalk-server/Photo.Jpeg"
+}
+
+test_nested_path_image() {
+    assert_match "/signalk-server/a/b/c/deep.svg"
+}
+
+test_dotted_filename_image_is_served() {
+    # A filename with dots before the extension still resolves to an image
+    # request; Signal K applies its own (auth_mode: none -> OIDC) authz on
+    # both :443 and :4430, so this is acceptable and intended to match.
+    assert_match "/signalk-server/report.v1.2.svg"
+}
+
+# --- Should fall through to the :4430 redirect (navigation) ------------------
+
+test_root_and_extensionless_paths_redirect() {
+    assert_no_match "/signalk-server/" || return 1
+    assert_no_match "/signalk-server/admin/" || return 1
+    assert_no_match "/signalk-server/plugins"
+}
+
+test_html_js_css_redirect() {
+    assert_no_match "/signalk-server/admin/index.html" || return 1
+    assert_no_match "/signalk-server/admin/main.js" || return 1
+    assert_no_match "/signalk-server/admin/style.css"
+}
+
+test_wrong_prefix_does_not_match() {
+    assert_no_match "/other/icon.svg" || return 1
+    # No slash boundary after "signalk-server": must not match.
+    assert_no_match "/signalkserver/icon.svg"
+}
+
+run_test test_rule_carries_case_insensitive_flag
+run_test test_canonical_homarr_icon_path
+run_test test_each_lowercase_extension
+run_test test_jpeg_gif_avif_extensions
+run_test test_uppercase_extensions_match
+run_test test_nested_path_image
+run_test test_dotted_filename_image_is_served
+run_test test_root_and_extensionless_paths_redirect
+run_test test_html_js_css_redirect
+run_test test_wrong_prefix_does_not_match
+
+echo ""
+echo "Passed: $PASSES   Failed: $FAILS"
+[ "$FAILS" -eq 0 ]


### PR DESCRIPTION
## Why

The Homarr dashboard renders Signal K plugin card icons via path-only URLs like `/signalk-server/@signalk/app-dock/app-icon.svg`. By default these match the auto-generated `redirect-signalk-server-https@file` router (priority 100, `PathPrefix(/signalk-server/)`) and get 307-redirected to `https://<host>:4430/@signalk/app-dock/app-icon.svg`.

That redirect crosses a port boundary. Chromium-family browsers key cert exceptions by `(host, port, leaf-fingerprint)`, so a user without the device CA installed sees broken icons until they manually navigate to `:4430` and click through the cert warning — once per (hostname, app port) tuple they ever visit. Safari requires this even with the prior self-signed cert default (regression flagged in test session). Multi-hostname access (`<host>.local` + DHCP-domain FQDN) multiplies the count.

Static images aren't navigation; they don't need origin isolation from the dashboard. Same-origin serving means the dashboard's already-granted `:443` cert exception covers them.

## What

New `assets/traefik/dynamic/signalk-server-icons.yml` defining:

- Router `signalk-server-icons-on-443` matching `PathRegexp(^/signalk-server/.+\.(svg|png|ico|jpg|webp)$)` at priority 200, beating the redirect router (priority 100).
- StripPrefix middleware to map `/signalk-server/<asset>` → `/<asset>` for the backend.
- Service pointing at the SK Server backend on `http://host.docker.internal:3000` — same target the per-app `:4430` router uses.
- `strip-hsts@file` middleware (from #161) wired in so the new router doesn't reintroduce the HSTS leak.

Scope intentionally narrow: extensions cover icons/images only. HTML, JS, and CSS are excluded because a SK plugin SPA loaded under a `/signalk-server/...` prefix on the dashboard origin would silently break (webapps assume `/` as their root and embed absolute paths). Plugin navigation continues through the existing 307→`:4430` path so each app keeps its `/`-rooted origin.

## How verified

Live device:

- **Icon URL via :443:** `curl -ks -D - -o /dev/null https://halosdev.local/signalk-server/@signalk/app-dock/app-icon.svg` → `HTTP/2 200`, `content-type: image/svg+xml`, no `Strict-Transport-Security`.
- **HTML navigation regression:** `/signalk-server/admin/` → `HTTP/2 302` to `:4430`, unchanged.
- **SPA bundle regression:** `/signalk-server/admin/main.js` → `HTTP/2 302` to `:4430`, unchanged.
- **Other whitelisted extensions** (png, ico, jpg, webp): reach the backend (404 from SK Server's HTML 404 page, proving the proxy works for them too).
- **Traefik API confirms** `signalk-server-icons-on-443@file` is enabled with the expected rule and priority 200.

## Dependencies

- Built on top of #161 (HSTS strip middleware) — the new router references `strip-hsts@file`. PR base is set to that branch so the diff reads cleanly. Will retarget to `main` once #161 merges, or rebase if a different order is preferred.

## Future work

This pattern is signalk-server-specific. If other per-app backends grow similar needs (Homarr fetching status badges, etc.), generalizing through `configure-container-routing` with a `static_assets` opt-in in `routing.d/<app>.yml` would be the clean path. Out of scope here.