### PR TITLE
fix(certs): sticky domain resolution to stop one-re-sign-per-boot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,8 +128,13 @@ hostname list:
 function whose stdout becomes the resolved domain. Gated on `declare -F`
 so a stray environment export cannot short-circuit production resolution
 or trigger command execution. When honored, the function's output
-(including empty) is authoritative — no fall-through. Tests use this to
-pin empty-domain behavior independently of the host network.
+(including empty) replaces the live-resolution chain (`hostname -d` /
+`nmcli`) — no fall-through to it. The sticky-domain layer still runs on
+top, exactly as it does for the real chain: with persistence enabled an
+injected empty can be backfilled from the persisted domain, and an
+injected (safe) value is persisted. Tests therefore pin empty-domain
+behavior by also controlling persistence — set `HALOS_HOSTNAMES_DOMAIN_STATE`
+empty to disable it, or point it at a scratch state file.
 
 **OIDC client snippet placeholder convention.** App `prestart.sh` scripts
 that drop OIDC client snippets into `/etc/halos/oidc-clients.d/` should

--- a/assets/hostnames.conf
+++ b/assets/hostnames.conf
@@ -17,8 +17,11 @@
 # Domain resolution order (first non-empty wins):
 #   1. `hostname -d` (admin-set via /etc/hosts or hostnamectl)
 #   2. `nmcli -t -f IP4.DOMAIN device show` (DHCP option 15, when NetworkManager is present)
-# When no domain resolves, lines using ${fqdn} or ${domain} are silently
-# skipped (logged as HALOS_HOSTNAMES_SKIP); other entries continue to apply.
+# The last-resolved domain is persisted, so once a domain has ever resolved
+# it is reused at early boot before the network settles (keeps the cert SANs
+# stable across reboots). Until a domain first resolves, lines using ${fqdn}
+# or ${domain} are silently skipped (logged as HALOS_HOSTNAMES_SKIP); other
+# entries continue to apply.
 #
 # Examples:
 #   ${hostname}.local        # mDNS -- works on the LAN without configuration

--- a/assets/lib-hostnames.sh
+++ b/assets/lib-hostnames.sh
@@ -90,7 +90,14 @@ _halos_domain_safe() {
 # Resolved values are validated by _halos_domain_safe; anything that fails
 # (whitespace, NUL, shell metacharacters, non-DNS characters) is treated
 # as no-domain and the chain falls through.
-# Echoes the empty string when nothing resolves; never errors.
+#
+# Sticky behavior: the last-known-good domain is persisted to
+# $HALOS_HOSTNAMES_DOMAIN_STATE (unset → /var/lib/halos/resolved-domain;
+# set-but-empty → disabled). When the live chain resolves nothing, the
+# persisted value is reused instead of returning empty, so a domain that
+# resolved on an earlier boot stays available while the network settles.
+# All state I/O is best-effort and never fails resolution. Echoes the empty
+# string when nothing resolves and nothing is persisted; never errors.
 #
 # Cached per `halos_load_hostnames` invocation in HALOS_HOSTNAMES_DOMAIN_CACHE.
 # Note: empty-string is a valid cached value (meaning "resolver completed,
@@ -106,47 +113,89 @@ _halos_resolve_domain() {
 
     # 1. Test injection seam — only when it names a defined shell function.
     if [ -n "${HALOS_DOMAIN_RESOLVER:-}" ] && declare -F "$HALOS_DOMAIN_RESOLVER" >/dev/null 2>&1; then
-        d="$("$HALOS_DOMAIN_RESOLVER" 2>/dev/null || true)"
-        d="$(_halos_trim "$d")"
         # Injected resolver output is authoritative (including empty) so
         # tests can pin empty-domain behavior. No domain-shape validation.
-        HALOS_HOSTNAMES_DOMAIN_CACHE="$d"
-        printf '%s' "$d"
-        return 0
-    fi
-
-    # 2. hostname -d (admin-configured).
-    d="$(_halos_trim "$(hostname -d 2>/dev/null || true)")"
-    if [ -n "$d" ] && ! _halos_domain_safe "$d"; then
-        _halos_log "HALOS_HOSTNAMES_SKIP: hostname -d returned unsafe value, ignoring"
-        d=""
-    fi
-
-    # 3. nmcli (DHCP-provided), with timeout so a hung NM can't block prestart.
-    if [ -z "$d" ] && command -v nmcli >/dev/null 2>&1; then
-        local nmcli_cmd
-        if command -v timeout >/dev/null 2>&1; then
-            nmcli_cmd="timeout 2 nmcli"
-        else
-            nmcli_cmd="nmcli"
+        d="$("$HALOS_DOMAIN_RESOLVER" 2>/dev/null || true)"
+        d="$(_halos_trim "$d")"
+    else
+        # 2. hostname -d (admin-configured).
+        d="$(_halos_trim "$(hostname -d 2>/dev/null || true)")"
+        if [ -n "$d" ] && ! _halos_domain_safe "$d"; then
+            _halos_log "HALOS_HOSTNAMES_SKIP: hostname -d returned unsafe value, ignoring"
+            d=""
         fi
-        local line value
-        while IFS= read -r line; do
-            # Format: IP4.DOMAIN[N]:value (terse mode, colon-separated).
-            value="${line#*:}"
-            # nmcli emits "--" for empty fields; skip those.
-            if [ -n "$value" ] && [ "$value" != "--" ]; then
-                value="$(_halos_trim "$value")"
-                if _halos_domain_safe "$value"; then
-                    d="$value"
-                    break
+
+        # 3. nmcli (DHCP-provided), with timeout so a hung NM can't block prestart.
+        if [ -z "$d" ] && command -v nmcli >/dev/null 2>&1; then
+            local nmcli_cmd
+            if command -v timeout >/dev/null 2>&1; then
+                nmcli_cmd="timeout 2 nmcli"
+            else
+                nmcli_cmd="nmcli"
+            fi
+            local line value
+            while IFS= read -r line; do
+                # Format: IP4.DOMAIN[N]:value (terse mode, colon-separated).
+                value="${line#*:}"
+                # nmcli emits "--" for empty fields; skip those.
+                if [ -n "$value" ] && [ "$value" != "--" ]; then
+                    value="$(_halos_trim "$value")"
+                    if _halos_domain_safe "$value"; then
+                        d="$value"
+                        break
+                    fi
+                fi
+            done < <($nmcli_cmd -t -f IP4.DOMAIN device show 2>/dev/null || true)
+        fi
+    fi
+
+    # Downstream consumers (cert SANs, Authelia per-hostname cookies, OIDC
+    # redirect_uris) key off this domain and must see a value that is stable
+    # across reboots — not one that vanishes and returns as the network
+    # settles. The live chain returns nothing during early boot, before
+    # NetworkManager has assigned a DHCP domain, so persist the last-known-good
+    # value and reuse it whenever the live chain is empty: a transient empty
+    # resolution then keeps the previously-resolved domain instead of dropping
+    # it. A genuinely different live domain overwrites the stored value, so
+    # real domain changes still propagate.
+    #
+    # State path: unset → production default; set-empty → disabled (stateless).
+    # All I/O is best-effort — resolution must never fail, because consumers
+    # source this library under set -e.
+    local state_file="${HALOS_HOSTNAMES_DOMAIN_STATE-/var/lib/halos/resolved-domain}"
+    if [ -n "$state_file" ]; then
+        if [ -n "$d" ] && _halos_domain_safe "$d"; then
+            # Skip the write when the stored value already matches: the common
+            # case is the same domain every boot, and rewriting it is needless
+            # flash wear on the SD/eMMC these devices run from.
+            local stored=""
+            [ -r "$state_file" ] && stored="$(_halos_trim "$(cat "$state_file" 2>/dev/null || true)")"
+            if [ "$stored" != "$d" ]; then
+                mkdir -p "$(dirname "$state_file")" 2>/dev/null || true
+                # Per-PID temp: concurrent loader runs (cert-renewal timer,
+                # prestart on container restart, manual reload-oidc-clients)
+                # must not truncate each other's write to a shared temp name.
+                local tmp="${state_file}.$$"
+                if printf '%s' "$d" > "$tmp" 2>/dev/null && mv -f "$tmp" "$state_file" 2>/dev/null; then
+                    :
+                else
+                    rm -f "$tmp" 2>/dev/null || true
+                    _halos_log "HALOS_HOSTNAMES_WARN: could not persist resolved domain to $state_file (stickiness inactive — cert may re-sign each boot)"
                 fi
             fi
-        done < <($nmcli_cmd -t -f IP4.DOMAIN device show 2>/dev/null || true)
+        elif [ -z "$d" ] && [ -r "$state_file" ]; then
+            local stored
+            stored="$(_halos_trim "$(cat "$state_file" 2>/dev/null || true)")"
+            if [ -n "$stored" ] && _halos_domain_safe "$stored"; then
+                _halos_log "HALOS_HOSTNAMES_STICKY: live domain empty, reusing persisted domain: $stored"
+                d="$stored"
+            fi
+        fi
     fi
 
     HALOS_HOSTNAMES_DOMAIN_CACHE="$d"
     printf '%s' "$d"
+    return 0
 }
 
 # Validate IPv4 octet bounds (regex only matches digit shape).

--- a/debian/postinst
+++ b/debian/postinst
@@ -44,6 +44,13 @@ EOF
         mkdir -p /etc/halos/traefik-dynamic.d
         mkdir -p /run/halos/routing-labels
 
+        # Sticky-domain state for lib-hostnames.sh. The resolver persists the
+        # last-known-good DHCP domain here so the FQDN cert SAN stays stable
+        # across reboots (see docs/HOSTNAMES.md). Created at install so the
+        # first resolver run can write it even on a read-only-/var-leaning
+        # setup, rather than relying on a best-effort runtime mkdir.
+        mkdir -p /var/lib/halos
+
         # Operator drop slot for a custom device CA. If both ca.crt and
         # ca.key are present and valid, halos_ca_select_active uses them
         # instead of the auto-generated CA. Empty by default; mode 0700

--- a/docs/HOSTNAMES.md
+++ b/docs/HOSTNAMES.md
@@ -42,11 +42,32 @@ Resolution order, first non-empty wins:
 `declare -F` so a stray environment export cannot short-circuit
 production resolution.)
 
-If no domain resolves, lines using `${fqdn}` or `${domain}` are silently
-skipped (logged as `HALOS_HOSTNAMES_SKIP`); other entries continue to
-apply. Boot proceeds normally — the device just doesn't answer on its
-DHCP-derived FQDN until the domain is set or DHCP lease changes are
-followed by a service restart.
+**Sticky domain.** The last-known-good domain is persisted to
+`/var/lib/halos/resolved-domain`. When the chain above resolves nothing —
+typically at early boot, before NetworkManager has settled — the persisted
+value is reused instead of being treated as "no domain" (logged as
+`HALOS_HOSTNAMES_STICKY`). This stops the cert service from signing a
+`.local`-only leaf at boot and re-signing minutes later once DHCP settles
+(one re-sign per boot). A genuinely *different* resolved domain overwrites
+the stored value, so real domain changes still apply. Trade-off: a device
+that *permanently* moves to a network with no DHCP domain keeps its old
+FQDN as a stale-but-harmless cert SAN until a domain resolves again.
+
+The state file is shared by every loader consumer (the cert service,
+`prestart.sh`, and `reload-oidc-clients`), which is what keeps their views
+of the hostname set consistent. The first of them to observe a *new* live
+domain rewrites the file; the others read it. Note the refresh boundaries:
+the cert service re-signs as soon as it sees a domain change, but the
+Authelia cookie / OIDC `redirect_uris` config rendered by `prestart.sh`
+only picks up the new domain on its next run (a `halos-core-containers`
+restart). On a genuine domain change, restart the service to realign SSO
+config with the cert.
+
+If no domain has *ever* resolved (nothing persisted yet), lines using
+`${fqdn}` or `${domain}` are silently skipped (logged as
+`HALOS_HOSTNAMES_SKIP`); other entries continue to apply. Boot proceeds
+normally — the device just doesn't answer on its DHCP-derived FQDN until
+the domain first resolves.
 
 ## Single-label hostnames — don't use them
 

--- a/tests/test-lib-hostnames.sh
+++ b/tests/test-lib-hostnames.sh
@@ -38,6 +38,11 @@ _reset_state() {
     unset HALOS_HOSTNAMES_DNS HALOS_HOSTNAMES_IPS
     unset HALOS_HOSTNAMES_CANONICAL HALOS_HOSTNAMES_FALLBACK
     unset HALOS_HOSTNAMES_FALLBACK_REASON
+    # Disable sticky-domain persistence by default (set-but-empty). Tests
+    # that exercise stickiness opt in by pointing this at a tmp state file
+    # after _reset_state. Leaving it set-empty keeps every other test on the
+    # stateless resolution path, deterministic regardless of who runs them.
+    HALOS_HOSTNAMES_DOMAIN_STATE=""
     # shellcheck source=/dev/null
     . "$LIB"
 }
@@ -587,8 +592,167 @@ test_expand_redirect_uri_default_fallback() {
     assert_eq "$out" "https://${short}.local/cb," "fallback should expand to single canonical URI"
 }
 
+# Unit 1b: sticky domain (Bug A — one re-sign per boot) ----------------------
+
+test_sticky_domain_reuses_on_transient_empty() {
+    # Boot 1: DHCP domain resolves → persisted. Boot 2: early-boot live
+    # resolution is empty → the persisted domain is reused instead of
+    # dropping the FQDN. This is the core Bug A fix.
+    local f="$TMPDIR_ROOT/sticky1.conf"
+    local state="$TMPDIR_ROOT/sticky1.state"
+    rm -f "$state"
+    write_conf "$f" '${fqdn}'
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_hal
+    halos_load_hostnames
+    local d1; d1="$(_halos_resolve_domain)"
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_empty
+    halos_load_hostnames
+    local d2; d2="$(_halos_resolve_domain)"
+    unset HALOS_DOMAIN_RESOLVER HALOS_HOSTNAMES_DOMAIN_STATE
+
+    assert_eq "$d1" "hal" "boot 1 resolves and persists hal" || return 1
+    assert_eq "$d2" "hal" "boot 2 reuses persisted hal despite empty live resolution"
+}
+
+test_sticky_domain_genuine_change_overwrites() {
+    # A genuinely different live domain must overwrite the stored value, so
+    # real network/domain changes still produce one legitimate re-sign.
+    local f="$TMPDIR_ROOT/sticky2.conf"
+    local state="$TMPDIR_ROOT/sticky2.state"
+    rm -f "$state"
+    write_conf "$f" '${fqdn}'
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_hal
+    halos_load_hostnames
+    local d1; d1="$(_halos_resolve_domain)"
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_example_com
+    halos_load_hostnames
+    local d2; d2="$(_halos_resolve_domain)"
+    unset HALOS_DOMAIN_RESOLVER HALOS_HOSTNAMES_DOMAIN_STATE
+
+    assert_eq "$d1" "hal" "first live domain is hal" || return 1
+    assert_eq "$d2" "example.com" "a different live domain overwrites the persisted value"
+}
+
+test_sticky_domain_disabled_keeps_stateless_behavior() {
+    # With persistence disabled (set-empty state path), an empty live
+    # resolution must still yield empty — the pre-fix stateless contract.
+    local f="$TMPDIR_ROOT/sticky3.conf"
+    write_conf "$f" '${fqdn}'
+
+    _reset_state "$f"   # leaves HALOS_HOSTNAMES_DOMAIN_STATE=""
+    HALOS_DOMAIN_RESOLVER=_resolver_hal
+    halos_load_hostnames
+    local d1; d1="$(_halos_resolve_domain)"
+
+    _reset_state "$f"
+    HALOS_DOMAIN_RESOLVER=_resolver_empty
+    halos_load_hostnames
+    local d2; d2="$(_halos_resolve_domain)"
+    unset HALOS_DOMAIN_RESOLVER
+
+    assert_eq "$d1" "hal" "stateless: first resolver still returns hal" || return 1
+    assert_eq "$d2" "" "stateless: empty resolver yields empty (no persistence)"
+}
+
+test_sticky_domain_garbage_not_persisted() {
+    # An unsafe live value (shell metacharacters) must never be persisted,
+    # so it can't be replayed into cert SANs on a later boot.
+    local f="$TMPDIR_ROOT/sticky4.conf"
+    local state="$TMPDIR_ROOT/sticky4.state"
+    rm -f "$state"
+    write_conf "$f" '${fqdn}'
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_with_dollar
+    halos_load_hostnames   # primes the cache → triggers the persist attempt
+
+    # Assert the persist-side guard directly: nothing unsafe reached the state
+    # file. Checking d2 alone would also pass if the read-side guard masked a
+    # persisted-garbage regression, so this is the load-bearing assertion.
+    if [ -s "$state" ]; then
+        printf 'garbage was persisted to state file: %q\n' "$(cat "$state")" >&2
+        return 1
+    fi
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_empty
+    halos_load_hostnames
+    local d2; d2="$(_halos_resolve_domain)"
+    unset HALOS_DOMAIN_RESOLVER HALOS_HOSTNAMES_DOMAIN_STATE
+
+    assert_eq "$d2" "" "garbage live value must not be persisted for later reuse"
+}
+
+test_sticky_domain_first_boot_returns_empty() {
+    # Persistence enabled but nothing stored yet (true first boot): an empty
+    # live resolution must yield empty and create no state file — stickiness
+    # must never fabricate a domain out of thin air.
+    local f="$TMPDIR_ROOT/sticky6.conf"
+    local state="$TMPDIR_ROOT/sticky6.state"
+    rm -f "$state"
+    write_conf "$f" '${fqdn}'
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_empty
+    halos_load_hostnames
+    local d; d="$(_halos_resolve_domain)"
+    unset HALOS_DOMAIN_RESOLVER HALOS_HOSTNAMES_DOMAIN_STATE
+
+    assert_eq "$d" "" "first boot with empty store must return empty, not a fabricated domain" || return 1
+    if [ -e "$state" ]; then
+        printf 'no state file should be created when nothing ever resolved\n' >&2
+        return 1
+    fi
+}
+
+test_sticky_fqdn_stable_across_boots() {
+    # Consumer-level outcome: the hostnames hash that drives the cert
+    # sentinel is identical across a domain-resolving boot and a subsequent
+    # empty-resolution boot — so halos-manage-certs does NOT re-sign.
+    local f="$TMPDIR_ROOT/sticky5.conf"
+    local state="$TMPDIR_ROOT/sticky5.state"
+    rm -f "$state"
+    write_conf "$f" '${hostname}.local' '${fqdn}'
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_hal
+    halos_load_hostnames
+    local h1; h1="$(halos_hostnames_hash)"
+
+    _reset_state "$f"
+    HALOS_HOSTNAMES_DOMAIN_STATE="$state"
+    HALOS_DOMAIN_RESOLVER=_resolver_empty
+    halos_load_hostnames
+    local h2; h2="$(halos_hostnames_hash)"
+    unset HALOS_DOMAIN_RESOLVER HALOS_HOSTNAMES_DOMAIN_STATE
+
+    assert_eq "$h1" "$h2" "hostname hash stable across boots → no per-boot re-sign"
+}
+
 # ---------------------------------------------------------------------------
 
+run_test test_sticky_domain_reuses_on_transient_empty
+run_test test_sticky_domain_genuine_change_overwrites
+run_test test_sticky_domain_disabled_keeps_stateless_behavior
+run_test test_sticky_domain_garbage_not_persisted
+run_test test_sticky_domain_first_boot_returns_empty
+run_test test_sticky_fqdn_stable_across_boots
 run_test test_happy_path_dns_and_ip
 run_test test_comments_and_blank_lines_ignored
 run_test test_missing_file_fallback


### PR DESCRIPTION
## Why

`halos-manage-certs` re-signs the TLS leaf once on every boot.

The cert service is ordered `Before=halos-core-containers.service`, so it runs before NetworkManager has settled. The domain resolver chain (`hostname -d` → `nmcli`) returns nothing, the `${fqdn}` line in `hostnames.conf` soft-drops, and the leaf is signed with `.local`-only SANs — with the sentinel stored for that set. ~15 min later the renewal timer fires, DHCP has provided a domain, `${fqdn}` now expands to `<host>.hal`, the hostname hash changes, the sentinel mismatches, and the leaf is re-signed. Verified on halosdev.local: boot signed `[halosdev.local]`, the timer logged "Hostname list or CA changed, re-signing" and expanded to `[halosdev.hal, halosdev.local]`.

The `.hal` SAN is wanted (real unicast DNS, more robust than mDNS `.local`). The bug is the *instability of when it's included*, not the SAN.

## How

Make `_halos_resolve_domain` sticky: persist the last-known-good domain and reuse it when the live chain resolves nothing. After the first provisioning, every subsequent boot signs with the full SAN set immediately → stable hostname hash → no re-sign. A genuinely different live domain overwrites the stored value, so real domain changes still produce one legitimate re-sign.

Fixing this in the resolver (not in cert code) stabilizes the hostname set for every consumer — cert SANs, Authelia per-hostname cookies, and OIDC `redirect_uris`.

- State at `/var/lib/halos/resolved-domain`; override via `HALOS_HOSTNAMES_DOMAIN_STATE`, set-empty disables (test isolation). All state I/O is best-effort and never fails resolution (consumers run under `set -e`). Persisted writes are gated on `_halos_domain_safe`, so a garbage/injected value can't be replayed into cert SANs.
- Default path is fixed (not derived from `CONTAINER_DATA_ROOT`) so all loader consumers agree without each setting the env.

**Trade-off:** a device that *permanently* moves to a network with no DHCP domain keeps its old FQDN as a stale-but-harmless cert SAN until a domain resolves again. Deliberate — distinguishing transient from permanent absence isn't worth the complexity. `After=network-online.target` was rejected (it would push the whole stack behind `NetworkManager-wait-online` on every offline boot).

## Tests

5 new tests in `test-lib-hostnames.sh`: reuse-on-transient-empty, genuine-change-overwrites, disabled-keeps-stateless, garbage-not-persisted, and a consumer-level check that the hostname hash is identical across a resolving boot and a subsequent empty-resolution boot (the outcome that gates re-signing). Full suite green.

## Verify on a device

Reboot twice and confirm `halos-manage-certs` logs no "Hostname list or CA changed" re-sign on the second boot.

Closes #164. Extracted from #160 (closed — self-signed revert dropped, no benefit once #161/#162 fixed the HSTS symptom).
