### PR TITLE
fix(run): force-install on deploy regardless of version

### DIFF
--- a/run
+++ b/run
@@ -89,8 +89,32 @@ function deploy {
     remote_debs="$remote_debs /tmp/$(basename "$deb")"
   done
 
-  ssh "$target" "sudo apt install -y --allow-downgrades $remote_debs"
-  echo "Deployment complete."
+  # Force-install regardless of version. Local dev builds carry an arbitrary
+  # changelog version (the committed debian/changelog, not VERSION-derived),
+  # and we can't know what version the target already runs — a CI release, a
+  # prerelease, or a prior dev build. apt compares versions, so it would skip
+  # a same-version install or refuse a lower one and silently deploy nothing.
+  # dpkg -i installs the exact .deb unconditionally. Then run apt-get -f
+  # install unconditionally (not only on dpkg failure): dpkg unpacks but
+  # leaves the package unconfigured when a dependency is missing, and -f
+  # install reconciles that; it's a cheap no-op when nothing is broken.
+  #
+  # The stack restart is gated (&&) on -f install succeeding, so we never
+  # bounce the stack onto a half-configured package. Restart is needed
+  # because the package postinst only enables the unit — without it the
+  # running containers keep their old bind-mounted config. The unit's
+  # ExecStop=docker compose down / ExecStart=docker compose up makes a
+  # restart a full recreate, so new compose and configs take effect.
+  # Propagate remote failure rather than always claiming success: the remote
+  # command's exit status reflects apt-get -f install (dependency resolution)
+  # and the restart, so a broken install or a failed start surfaces here
+  # instead of a misleading "complete".
+  if ssh "$target" "sudo dpkg -i $remote_debs; sudo apt-get -f install -y && sudo systemctl restart halos-core-containers.service"; then
+    echo "Deployment complete (package force-installed; stack restarting — containers may take ~30s to settle)."
+  else
+    echo "Deployment FAILED on $target — see the dpkg/apt/systemctl output above." >&2
+    return 1
+  fi
 }
 
 function deploy-build {


### PR DESCRIPTION
## Why

`./run deploy` could silently deploy **nothing**. It used `apt install --allow-downgrades <deb>`, which compares versions before installing. Two facts make that unreliable for a dev-deploy-to-test-device workflow:

- Local builds carry an arbitrary changelog version (the committed `debian/changelog`, frozen at `0.2.1-1`, not derived from `VERSION`), and we don't bump it per dev build.
- We can't know what version the target already runs — a CI release (`0.4.1-3`), a prerelease, or a prior dev build.

So apt would skip a same-version install ("already newest") or refuse a lower one — deploying nothing while reporting success. This bit a real verification: pushed config changes never reached the device.

Aligning local build versions with `VERSION` would only narrow the gap, not close it (we still can't know the target's version, and can't bump per build). The robust fix is to stop comparing versions at deploy time.

## How

```
sudo dpkg -i <debs>; sudo apt-get -f install -y && sudo systemctl restart halos-core-containers.service
```

- **`dpkg -i`** installs the exact `.deb` unconditionally — no version comparison.
- **`apt-get -f install` unconditionally** afterward: `dpkg` unpacks but leaves a package unconfigured if a dependency is missing; `-f install` reconciles that, and is a cheap no-op when nothing is broken. (Running it always, rather than only on `dpkg` failure, avoids relying on dpkg's exit-code nuances.)
- **Restart gated on `-f install` succeeding (`&&`)** so the stack never bounces onto a half-configured package. The restart is necessary because the package postinst only *enables* the unit — without it, running containers keep their old bind-mounted config. The unit's `ExecStop=docker compose down` / `ExecStart=docker compose up` makes a restart a full recreate, so new compose and configs take effect.

## Verification

On halosdev (`pi@halosdev.local`):
- Deploy over an identical installed version now logs `Unpacking halos-core-containers (0.2.1-1) over (0.2.1-1)` — a real install, where `apt` previously no-op'd.
- `ca-download` and the rest of the stack recreate (new container IDs, fresh `StartedAt`) and return to `healthy`; `/ca/` → 200 after settle (~30s).

## Note

The deploy now reports completion while the stack is still recreating (~30s to settle), since `systemctl restart` returns once `docker compose up` has launched. The committed-and-stale `debian/changelog` is a separate hygiene issue (it makes `dpkg -l` show `0.2.1`); this PR deliberately doesn't touch versioning policy — the force-install makes it a non-blocker.
