### PR TITLE
fix(certs): macOS install targets System keychain, not login

### DIFF
--- a/assets/ca-download/landing/index.html
+++ b/assets/ca-download/landing/index.html
@@ -126,9 +126,9 @@
         <summary>macOS</summary>
         <ol>
           <li>Click <strong>Download</strong> above. <code>halos-ca.crt</code> lands in Downloads.</li>
-          <li>Double-click the file. Keychain Access opens — add it to the <strong>login</strong> keychain.</li>
-          <li>In Keychain Access, find the HaLOS CA under <em>Certificates</em> and double-click it.</li>
-          <li>Expand <strong>Trust</strong> and set <em>When using this certificate</em> to <strong>Always Trust</strong>. Close the window and enter your password when prompted. <span class="caveat">This is the mandatory trust step — adding the certificate without it leaves the warnings in place.</span></li>
+          <li>Double-click the file. Keychain Access opens and adds the certificate to the <strong>System</strong> keychain (if it asks which keychain, choose System); enter an admin password if prompted.</li>
+          <li>It's installed but not yet trusted. In Keychain Access, find the HaLOS CA under <strong>System</strong> ▸ <em>Certificates</em> and double-click it.</li>
+          <li>Expand <strong>Trust</strong> and set <em>When using this certificate</em> to <strong>Always Trust</strong>. Close the window and authenticate. <span class="caveat">This trust step is mandatory and separate from the install — without it the warnings stay.</span></li>
           <li>Quit and reopen your browser.</li>
         </ol>
       </details>


### PR DESCRIPTION
## Why

The macOS section of the CA-trust landing page (shipped in #168) told users to add the CA to the **login** keychain. That contradicts the plan and is the weaker choice:

- The plan (`docs/plans/2026-05-28-001-feat-effortless-ca-trust-plan.md:219`) specifies the macOS happy path as "Keychain Access import → **System keychain** pick → trust dialog → Always Trust".
- Technically, login-keychain trust is per-user and less reliable across contexts; the **System** keychain is the conventional CA anchor (what `mkcert` and friends target via `add-trusted-cert -k /Library/Keychains/System.keychain`).

The "login" wording was implementation drift, not a decision.

## What

Update the macOS steps to:
- pick **System** in the *Add Certificates* dialog (which requires admin auth), and
- open the **System** keychain for the Always-Trust toggle.

Other platforms unchanged. `tests/test_landing_content.py` still passes (the `Always Trust` marker and section structure are unaffected).

Refs #159
