### PR TITLE
Unit 2: device-identifying auto-CA CN + unadopted refresh

### DIFF
--- a/assets/halos-manage-certs
+++ b/assets/halos-manage-certs
@@ -98,7 +98,7 @@ mkdir -p "${CERTS_DIR}"
 # silently falling back — operators who installed a custom CA can SSH to
 # diagnose, and silent fallback would orphan the trust anchor they
 # distributed.
-halos_ca_select_active "${CUSTOM_CA_DIR}" "${AUTO_CA_DIR}" "${SERVING_CA}"
+halos_ca_select_active "${CUSTOM_CA_DIR}" "${AUTO_CA_DIR}" "${SERVING_CA}" "${HALOS_DOMAIN}"
 CA_CRT="${HALOS_CA_ACTIVE_CRT}"
 CA_KEY="${HALOS_CA_ACTIVE_KEY}"
 echo "Active CA: ${CA_CRT} (mode=${HALOS_CA_ACTIVE_MODE})"
@@ -112,6 +112,36 @@ echo "Active CA: ${CA_CRT} (mode=${HALOS_CA_ACTIVE_MODE})"
 # tests run unprivileged.
 halos_ca_adoption_init "${ADOPTION_FILE}" "${AUTO_CA_DIR}/ca.crt" "${HALOS_CA_AUTO_CREATED:-0}"
 chown "${HALOS_CA_DOWNLOAD_UID}:${HALOS_CA_DOWNLOAD_UID}" "${ADOPTION_FILE}" 2>/dev/null || true
+
+# CN-refresh gate: keep the auto-CA's subject CN tracking the current hostname
+# while it is still unadopted (never downloaded), then freeze it. This is a
+# distinct trigger from the expiry/clock-skew self-heal regen inside
+# halos_ca_ensure_auto, which still fires regardless of adoption. Auto mode
+# only — operators own custom-CA CNs. The regen runs here, before any consumer
+# of the active CA (public publish, .mobileconfig, leaf re-sign), so every
+# run-end artifact reflects the one regenerated CA; a CA whose fingerprint
+# changes re-signs the leaf via the existing sentinel mismatch.
+# Skip when the hostname is unresolved: an empty domain cannot produce a stable
+# CN, and refreshing toward it would churn a new CA on every flap.
+if [ "${HALOS_CA_ACTIVE_MODE}" = "auto" ] && [ -n "${HALOS_DOMAIN}" ] \
+   && ! halos_ca_is_adopted "${ADOPTION_FILE}"; then
+    CURRENT_CN_HOST="$(halos_ca_cn_hostname "${CA_CRT}")"
+    if [ "${CURRENT_CN_HOST}" != "${HALOS_DOMAIN}" ]; then
+        # Re-check adoption immediately before the destructive regen: a download
+        # can flip the sentinel between the gate's first check and here, and
+        # regenerating an adopted CA would orphan the just-installed anchor.
+        if halos_ca_is_adopted "${ADOPTION_FILE}"; then
+            echo "Adoption raced ahead of the CN refresh; leaving the CA frozen."
+        else
+            echo "Auto-CA unadopted and its CN host (${CURRENT_CN_HOST:-none}) differs from ${HALOS_DOMAIN}; refreshing CA CN..."
+            rm -f "${AUTO_CA_DIR}/ca.crt" "${AUTO_CA_DIR}/ca.key"
+            if ! halos_ca_ensure_auto "${AUTO_CA_DIR}" "${HALOS_DOMAIN}"; then
+                echo "halos-manage-certs: CN-refresh regeneration failed; cert generation cannot continue" >&2
+                exit 1
+            fi
+        fi
+    fi
+fi
 
 # Publish the active CA's PEM bytes into the public dir the ca-download
 # sidecar bind-mounts. Refreshed unconditionally so the published bytes

--- a/assets/lib-ca.sh
+++ b/assets/lib-ca.sh
@@ -232,8 +232,14 @@ halos_ca_leaf_needs_renewal() {
 # healthy CA was reused unchanged. Read by halos_ca_adoption_init to decide a
 # sentinel-less CA's initial state — a CA born this run starts "pending"
 # (refresh-eligible), a pre-existing one is classified by its CN.
+#
+# <hostname> (optional) makes the subject CN device-identifying:
+# "HaLOS Device CA (<hostname>)" so devices are distinguishable in trust stores.
+# Omitted/empty yields the bare legacy CN; callers that don't care (tests) can
+# keep the one-arg form. Only affects a CA this call generates — an existing
+# healthy CA is reused with whatever CN it already has.
 halos_ca_ensure_auto() {
-    local out_dir="$1"
+    local out_dir="$1" hostname="${2:-}"
     # shellcheck disable=SC2034
     HALOS_CA_AUTO_CREATED=0
     if [ -z "$out_dir" ]; then
@@ -269,6 +275,11 @@ halos_ca_ensure_auto() {
     local not_before
     not_before=$(_halos_ca_not_before)
 
+    # Device-identifying subject CN when a hostname is supplied; bare legacy CN
+    # otherwise. The parenthetical form matches the .mobileconfig display string.
+    local subject="$HALOS_CA_SUBJECT"
+    [ -n "$hostname" ] && subject="/CN=${HALOS_CA_SUBJECT_CN_PREFIX} (${hostname})"
+
     # umask 077 ensures the openssl-created key file is 0600 from inception,
     # closing the race window between cert creation and chmod where another
     # local UID could open the key fd while it was world-readable.
@@ -277,7 +288,7 @@ halos_ca_ensure_auto() {
             -not_before "$not_before" \
             -keyout "$ca_key_new" \
             -out "$ca_crt_new" \
-            -subj "$HALOS_CA_SUBJECT" \
+            -subj "$subject" \
             -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
             -addext "keyUsage=critical,keyCertSign,cRLSign" \
             -addext "subjectKeyIdentifier=hash" \
@@ -356,10 +367,14 @@ halos_ca_validate_pair() {
     fi
 }
 
-# halos_ca_select_active <custom_dir> <auto_dir> <symlink_path>
+# halos_ca_select_active <custom_dir> <auto_dir> <symlink_path> [hostname]
 # Picks the active device CA: operator-supplied custom (when present + valid)
 # wins; otherwise the auto-CA at <auto_dir> is ensured and used. Updates
 # <symlink_path> to point at the active cert (atomic via `ln -sfn`).
+#
+# [hostname] is threaded to the auto branch only, so a freshly generated
+# auto-CA carries a device-identifying CN. Custom CAs are never touched — the
+# operator owns their CN.
 #
 # Sets globals on success:
 #   HALOS_CA_ACTIVE_CRT   path to active CA cert
@@ -376,7 +391,7 @@ halos_ca_validate_pair() {
 # dropping a custom CA can SSH to diagnose, and silent fallback would
 # invalidate their installed trust anchor without warning.
 halos_ca_select_active() {
-    local custom_dir="$1" auto_dir="$2" symlink_path="$3"
+    local custom_dir="$1" auto_dir="$2" symlink_path="$3" hostname="${4:-}"
     if [ -z "$custom_dir" ] || [ -z "$auto_dir" ] || [ -z "$symlink_path" ]; then
         echo "halos_ca_select_active: <custom_dir> <auto_dir> <symlink_path> all required" >&2
         return 2
@@ -413,7 +428,7 @@ halos_ca_select_active() {
         active_key="$custom_key"
         active_mode="custom"
     else
-        halos_ca_ensure_auto "$auto_dir" || return $?
+        halos_ca_ensure_auto "$auto_dir" "$hostname" || return $?
         active_crt="${auto_dir}/ca.crt"
         active_key="${auto_dir}/ca.key"
         active_mode="auto"
@@ -761,10 +776,26 @@ halos_ca_publish_public() {
 # format renders a lone CN as "CN=<value>" with no spacing, so the trailing
 # capture stops at the first RDN separator.
 _halos_ca_subject_cn() {
-    local crt="$1"
+    local crt="$1" subject
     [ -f "$crt" ] || return 1
-    openssl x509 -in "$crt" -noout -subject -nameopt RFC2253 2>/dev/null \
-        | sed -n 's/.*CN=\([^,]*\).*/\1/p'
+    # Capture openssl separately so its failure propagates — a pipe into sed
+    # would mask it behind sed's always-zero exit.
+    subject="$(openssl x509 -in "$crt" -noout -subject -nameopt RFC2253 2>/dev/null)" || return 1
+    printf '%s\n' "$subject" | sed -n 's/.*CN=\([^,]*\).*/\1/p'
+}
+
+# halos_ca_cn_hostname <crt_path>
+# Print the hostname embedded in a device-identifying CN
+# "HaLOS Device CA (<hostname>)". Prints nothing for a bare legacy CN or any
+# other subject — so a bare-CN CA always "differs" from a real hostname, which
+# is what lets a reset/Unit-1-era pending CA upgrade to a device CN on refresh.
+halos_ca_cn_hostname() {
+    local crt="$1" cn
+    cn="$(_halos_ca_subject_cn "$crt")" || return 0
+    if [[ "$cn" == "$HALOS_CA_SUBJECT_CN_PREFIX ("?*")" ]]; then
+        cn="${cn#"$HALOS_CA_SUBJECT_CN_PREFIX ("}"
+        printf '%s' "${cn%)}"
+    fi
 }
 
 # halos_ca_adoption_init <adoption_file> <auto_ca_crt> <auto_created>

--- a/tests/test-halos-manage-certs.sh
+++ b/tests/test-halos-manage-certs.sh
@@ -817,6 +817,138 @@ EOF
     assert_file "$(_cert_file "$d")" "leaf must still be produced after publish failure" || return 1
 }
 
+# --- Device-identifying CN + unadopted-refresh -----------------------------
+
+_inode() { stat -c '%i' "$1" 2>/dev/null || stat -f '%i' "$1"; }
+_ca_cn() { openssl x509 -in "$1" -noout -subject -nameopt RFC2253 | sed -n 's/.*CN=\([^,]*\).*/\1/p'; }
+# Content-based regeneration check. The CN-refresh gate deletes ca.crt before
+# regenerating, and Linux ext4/overlay reuses the just-freed inode number — so
+# an inode comparison gives a false negative for "the CA was regenerated".
+# Fingerprint is filesystem-agnostic.
+_ca_fp() { openssl x509 -in "$1" -noout -fingerprint -sha256; }
+
+test_first_boot_auto_ca_cn_names_device() {
+    local d; d=$(new_scratch cn_first_boot)
+    run_script "$d" >/dev/null
+    assert_eq "$(_ca_cn "$(_auto_ca_crt "$d")")" "HaLOS Device CA (fixture.test)" "first-boot auto CA CN must name the device" || return 1
+}
+
+test_pending_rename_refreshes_cn() {
+    # An unadopted device renamed before any download: the next run regenerates
+    # the CA with the new CN (distinct from a plain hostname change, which
+    # rotates only the leaf) and re-signs the leaf; the sentinel stays pending.
+    local d; d=$(new_scratch cn_rename)
+    run_script "$d" >/dev/null
+    local ca_before leaf_before
+    ca_before=$(_ca_fp "$(_auto_ca_crt "$d")")
+    leaf_before=$(_inode "$(_cert_file "$d")")
+    printf '%s\n' "renamed.test" > "$d/hostnames.conf"
+    sleep 1
+    run_script "$d" >/dev/null
+    [ "$(_ca_fp "$(_auto_ca_crt "$d")")" != "$ca_before" ] || { echo "auto CA must regenerate on unadopted rename"; return 1; }
+    [ "$(_inode "$(_cert_file "$d")")" != "$leaf_before" ] || { echo "leaf must re-sign after CA refresh"; return 1; }
+    assert_eq "$(_ca_cn "$(_auto_ca_crt "$d")")" "HaLOS Device CA (renamed.test)" "refreshed CN must name the new hostname" || return 1
+    assert_eq "$(cat "$(_adoption_file "$d")")" "pending" "sentinel stays pending after refresh" || return 1
+}
+
+test_pending_rename_end_of_run_consistency() {
+    # After an unadopted-rename run every artifact must reflect the SAME
+    # (regenerated) CA: a client installing the published or profile CA gets a
+    # leaf that chains to it.
+    local d; d=$(new_scratch cn_consistency)
+    run_script "$d" >/dev/null
+    printf '%s\n' "renamed.test" > "$d/hostnames.conf"
+    sleep 1
+    run_script "$d" >/dev/null
+    local auto_fp pub_fp
+    auto_fp=$(openssl x509 -in "$(_auto_ca_crt "$d")" -noout -fingerprint -sha256)
+    pub_fp=$(openssl x509 -in "$(_public_ca "$d")" -noout -fingerprint -sha256)
+    assert_eq "$pub_fp" "$auto_fp" "published CA must match the regenerated auto CA" || return 1
+    if ! openssl verify -CAfile "$(_public_ca "$d")" "$(_cert_file "$d")" >/dev/null 2>&1; then
+        echo "leaf must verify against the published (refreshed) CA"; return 1
+    fi
+    grep -q 'HaLOS Device CA (renamed.test)' "$(_public_mobileconfig "$d")" \
+        || { echo ".mobileconfig must reflect the refreshed device name"; return 1; }
+}
+
+test_pending_no_rename_no_regen() {
+    # No churn: a pending CA whose hostname is unchanged must not regenerate.
+    local d; d=$(new_scratch cn_no_rename)
+    run_script "$d" >/dev/null
+    local ca_before; ca_before=$(_ca_fp "$(_auto_ca_crt "$d")")
+    sleep 1
+    run_script "$d" >/dev/null
+    assert_eq "$(_ca_fp "$(_auto_ca_crt "$d")")" "$ca_before" "no CN refresh when hostname unchanged" || return 1
+}
+
+test_adopted_rename_freezes_cn() {
+    # Once adopted, a rename must NOT regenerate the CA — the installed anchor
+    # stays valid; the stale CN is the accepted cosmetic residual.
+    local d; d=$(new_scratch cn_adopted)
+    run_script "$d" >/dev/null
+    printf 'adopted' > "$(_adoption_file "$d")"
+    local ca_before; ca_before=$(_ca_fp "$(_auto_ca_crt "$d")")
+    printf '%s\n' "renamed.test" > "$d/hostnames.conf"
+    sleep 1
+    run_script "$d" >/dev/null
+    assert_eq "$(_ca_fp "$(_auto_ca_crt "$d")")" "$ca_before" "adopted CA must not regenerate on rename" || return 1
+    assert_eq "$(_ca_cn "$(_auto_ca_crt "$d")")" "HaLOS Device CA (fixture.test)" "frozen CN keeps the original hostname" || return 1
+}
+
+test_legacy_bare_cn_frozen_on_rename() {
+    # A pre-feature bare-CN CA is stamped adopted and must stay frozen with its
+    # bare CN even across a rename (migration safety).
+    local d; d=$(new_scratch cn_legacy_frozen)
+    _seed_auto_ca_with_cn "$d" "HaLOS Device CA" || { echo "seed failed"; return 1; }
+    run_script "$d" >/dev/null
+    assert_eq "$(cat "$(_adoption_file "$d")")" "adopted" "precondition: legacy stamped adopted" || return 1
+    local ca_before; ca_before=$(_ca_fp "$(_auto_ca_crt "$d")")
+    printf '%s\n' "renamed.test" > "$d/hostnames.conf"
+    sleep 1
+    run_script "$d" >/dev/null
+    assert_eq "$(_ca_fp "$(_auto_ca_crt "$d")")" "$ca_before" "legacy bare-CN CA must stay frozen on rename" || return 1
+    assert_eq "$(_ca_cn "$(_auto_ca_crt "$d")")" "HaLOS Device CA" "legacy CN stays bare" || return 1
+}
+
+test_expiry_regen_uses_current_hostname_when_adopted() {
+    # R6: the expiry/clock-skew self-heal regen is NOT gated by adoption and
+    # picks up the current hostname in the new CN.
+    local d; d=$(new_scratch cn_expiry_adopted)
+    run_script "$d" >/dev/null
+    printf 'adopted' > "$(_adoption_file "$d")"
+    local nb na
+    nb=$(date -u -d "@$(( $(date -u +%s) - 30 * 86400 ))" +%Y%m%d%H%M%SZ 2>/dev/null \
+        || date -u -r "$(( $(date -u +%s) - 30 * 86400 ))" +%Y%m%d%H%M%SZ)
+    na=$(date -u -d "@$(( $(date -u +%s) - 86400 ))" +%Y%m%d%H%M%SZ 2>/dev/null \
+        || date -u -r "$(( $(date -u +%s) - 86400 ))" +%Y%m%d%H%M%SZ)
+    openssl req -x509 -nodes -key "$(_auto_ca_key "$d")" -out "$(_auto_ca_crt "$d")" \
+        -not_before "$nb" -not_after "$na" -subj "/CN=HaLOS Device CA" \
+        -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1 \
+        || { echo "expired-CA fixture failed"; return 1; }
+    sleep 1
+    run_script "$d" >/dev/null
+    assert_eq "$(_ca_cn "$(_auto_ca_crt "$d")")" "HaLOS Device CA (fixture.test)" "expiry regen must pick up the current hostname even when adopted" || return 1
+    assert_eq "$(cat "$(_adoption_file "$d")")" "adopted" "sentinel stays adopted through self-heal" || return 1
+}
+
+test_custom_ca_cn_untouched() {
+    # R7: with a valid custom CA active, no CN-refresh logic runs and the
+    # operator's CN is left as-is.
+    local d; d=$(new_scratch cn_custom)
+    ( umask 077
+      openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+        -keyout "$d/custom-ca/ca.key" -out "$d/custom-ca/ca.crt" \
+        -subj "/CN=Acme Operator CA" \
+        -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1 ) \
+        || { echo "custom CA fixture failed"; return 1; }
+    chmod 0700 "$d/custom-ca"
+    run_script "$d" >/dev/null
+    assert_eq "$(_ca_cn "$d/custom-ca/ca.crt")" "Acme Operator CA" "custom CA CN must be untouched" || return 1
+    assert_no_file "$(_auto_ca_crt "$d")" "auto CA must not be generated in custom mode" || return 1
+}
+
 # ---------------------------------------------------------------------------
 
 run_test test_first_boot_bootstrap_creates_all_artifacts
@@ -844,6 +976,14 @@ run_test test_first_boot_initializes_adoption_pending
 run_test test_legacy_bare_cn_ca_stamped_adopted
 run_test test_adoption_sentinel_preserved_on_rerun
 run_test test_publish_public_failure_logs_error
+run_test test_first_boot_auto_ca_cn_names_device
+run_test test_pending_rename_refreshes_cn
+run_test test_pending_rename_end_of_run_consistency
+run_test test_pending_no_rename_no_regen
+run_test test_adopted_rename_freezes_cn
+run_test test_legacy_bare_cn_frozen_on_rename
+run_test test_expiry_regen_uses_current_hostname_when_adopted
+run_test test_custom_ca_cn_untouched
 
 echo
 echo "Passed: $PASSES, Failed: $FAILS"

--- a/tests/test-lib-ca.sh
+++ b/tests/test-lib-ca.sh
@@ -1626,6 +1626,73 @@ test_is_adopted_missing_returns_true() {
     halos_ca_is_adopted "$d/no-such-file"; assert_eq "$?" "0" "missing sentinel must read as adopted" || return 1
 }
 
+# --- Device-identifying CN -------------------------------------------------
+
+_ca_cn() { openssl x509 -in "$1" -noout -subject -nameopt RFC2253 | sed -n 's/.*CN=\([^,]*\).*/\1/p'; }
+
+test_ensure_auto_embeds_hostname_in_cn() {
+    local d="$TMPDIR_ROOT/case_cn_hostname"
+    mkdir -p "$d"
+    halos_ca_ensure_auto "$d" "halosdev.local" || return 1
+    assert_eq "$(_ca_cn "$d/ca.crt")" "HaLOS Device CA (halosdev.local)" "CN must embed hostname" || return 1
+}
+
+test_ensure_auto_bare_cn_without_hostname() {
+    # Back-compat: the one-arg form keeps the bare legacy CN.
+    local d="$TMPDIR_ROOT/case_cn_bare"
+    mkdir -p "$d"
+    halos_ca_ensure_auto "$d" || return 1
+    assert_eq "$(_ca_cn "$d/ca.crt")" "HaLOS Device CA" "no-hostname form must use bare CN" || return 1
+}
+
+test_ensure_auto_cn_round_trips() {
+    # cn_hostname must exactly invert the CN the generator wrote, or the
+    # refresh gate would churn (regenerate every run).
+    local d="$TMPDIR_ROOT/case_cn_roundtrip"
+    mkdir -p "$d"
+    halos_ca_ensure_auto "$d" "halosdev.local" || return 1
+    assert_eq "$(halos_ca_cn_hostname "$d/ca.crt")" "halosdev.local" "cn_hostname must round-trip" || return 1
+}
+
+test_cn_hostname_empty_for_bare_cn() {
+    local d="$TMPDIR_ROOT/case_cn_host_bare"
+    mkdir -p "$d"
+    _mk_ca_with_cn "$d/ca.crt" "HaLOS Device CA" || { echo "fixture failed"; return 1; }
+    assert_eq "$(halos_ca_cn_hostname "$d/ca.crt")" "" "bare CN must yield empty hostname" || return 1
+}
+
+test_cn_hostname_empty_for_custom_cn() {
+    local d="$TMPDIR_ROOT/case_cn_host_custom"
+    mkdir -p "$d"
+    _mk_ca_with_cn "$d/ca.crt" "Acme Corp Root" || { echo "fixture failed"; return 1; }
+    assert_eq "$(halos_ca_cn_hostname "$d/ca.crt")" "" "non-device CN must yield empty hostname" || return 1
+}
+
+test_select_active_threads_hostname_to_auto() {
+    local d="$TMPDIR_ROOT/case_select_hostname"
+    mkdir -p "$d/custom" "$d/auto"
+    halos_ca_select_active "$d/custom" "$d/auto" "$d/serving-ca.crt" "halosdev.local" || return 1
+    assert_eq "$HALOS_CA_ACTIVE_MODE" "auto" "must be auto mode" || return 1
+    assert_eq "$(_ca_cn "$d/auto/ca.crt")" "HaLOS Device CA (halosdev.local)" "auto CA must carry device CN" || return 1
+}
+
+test_select_active_custom_cn_untouched_with_hostname() {
+    # R7: a hostname arg must not rewrite a custom CA's operator-owned CN.
+    local d="$TMPDIR_ROOT/case_select_custom_cn"
+    mkdir -p "$d/custom" "$d/auto"
+    ( umask 077
+      openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+        -keyout "$d/custom/ca.key" -out "$d/custom/ca.crt" \
+        -subj "/CN=Acme Operator CA" \
+        -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1 )
+    chmod 0700 "$d/custom"
+    halos_ca_select_active "$d/custom" "$d/auto" "$d/serving-ca.crt" "halosdev.local" || return 1
+    assert_eq "$HALOS_CA_ACTIVE_MODE" "custom" "must be custom mode" || return 1
+    assert_eq "$(_ca_cn "$d/custom/ca.crt")" "Acme Operator CA" "custom CN must be untouched" || return 1
+    [ ! -f "$d/auto/ca.crt" ] || { echo "auto CA must not be generated in custom mode"; return 1; }
+}
+
 # ---------------------------------------------------------------------------
 
 run_test test_ensure_auto_generates_files
@@ -1730,6 +1797,13 @@ run_test test_is_adopted_pending_returns_false
 run_test test_is_adopted_adopted_returns_true
 run_test test_is_adopted_unrecognized_returns_true
 run_test test_is_adopted_missing_returns_true
+run_test test_ensure_auto_embeds_hostname_in_cn
+run_test test_ensure_auto_bare_cn_without_hostname
+run_test test_ensure_auto_cn_round_trips
+run_test test_cn_hostname_empty_for_bare_cn
+run_test test_cn_hostname_empty_for_custom_cn
+run_test test_select_active_threads_hostname_to_auto
+run_test test_select_active_custom_cn_untouched_with_hostname
 
 echo
 echo "Passed: $PASSES, Failed: $FAILS"


### PR DESCRIPTION
Second unit of the device-identifying auto-CA work (#176), building on the adoption sentinel from #177. Makes the auto-CA's subject CN device-identifying and keeps it fresh until first download, then freezes it.

## Behavior

- New auto-CAs carry `CN = HaLOS Device CA (<hostname>)` (matching the `.mobileconfig` display string), so fleet devices are distinguishable in Keychain Access / the iOS Profiles list / the Windows store — for both install and **deletion** (the original pain point).
- While the CA is **unadopted** (sentinel `pending`, never downloaded), a hostname change regenerates the CA with the new CN. Regenerating before first download is orphan-free — nothing is installed anywhere yet.
- Once **adopted** (or for a pre-feature bare-CN CA, stamped `adopted` on first sight in #177), the CN is **frozen**. A later rename leaves a cosmetically-stale CN but never orphans the installed anchor; TLS keeps working via the leaf SANs.

## How

- `assets/lib-ca.sh`: `halos_ca_ensure_auto` takes an optional hostname and builds the device CN (bare CN when omitted — the one-arg form still works for back-compat); `halos_ca_select_active` threads it to the auto branch only (custom CAs untouched, **R7**); `halos_ca_cn_hostname` extracts the embedded hostname (empty for a bare/non-device CN, which always "differs" — so a reset or Unit-1-era `pending` bare-CN CA upgrades to a device CN on its next refresh).
- `assets/halos-manage-certs`: passes `HALOS_DOMAIN` into selection and adds the **CN-refresh gate** — regenerate when the auto-CA is unadopted and its CN host differs from the resolved hostname. The gate runs **before any consumer of the active CA** (public publish, `.mobileconfig`, leaf re-sign), so every run-end artifact reflects the one regenerated CA. The changed fingerprint re-signs the leaf via the existing `.domain` sentinel.

The CN-refresh is a distinct trigger from the expiry/clock-skew self-heal regen, which stays **un-gated** by adoption and now also picks up the current hostname in its new CN (**R6**).

## End-of-run consistency

The key correctness contract: after any run, the served CA (`PUBLIC_CA_DIR/halos-ca.crt`), the CA in the `.mobileconfig`, the leaf's issuer, and the sentinel's fingerprint all reflect the **same** CA. Tested directly: after an unadopted-rename run the leaf verifies against the *published* `.crt`, the published CA fingerprint equals the auto-CA's, and the profile names the new host.

## Tests

- `tests/test-lib-ca.sh`: CN embedding, CN round-trip (no churn), `cn_hostname` for bare/custom CNs, hostname threading, custom-CN-untouched. (109 total)
- `tests/test-halos-manage-certs.sh`: first-boot CN names the device; unadopted rename refreshes CN + re-signs leaf + end-of-run consistency; no-churn when unchanged; adopted rename frozen; legacy bare-CN frozen; expiry self-heal picks up the hostname even when adopted; custom CA untouched. (33 total)

All suites green (`./run test`): lib-ca 109, manage-certs 33, endpoint 23, cgi 9, hostnames 45, traefik 10, pytest 19.

## Notes
- VERSION not bumped (cycle already open; CI walks `+N`).
- Requirements covered: R1, R4 (policy half), R6, R7, R8 (escape hatch = reset the sentinel to `pending`, documented for Unit 4).

Refs #176
Closes #178