### PR TITLE
Unit 4: document device-identifying CA name + adoption freeze

### DIFF
--- a/docs/CERTS.md
+++ b/docs/CERTS.md
@@ -25,8 +25,10 @@ journalctl -u halos-manage-certs.service -f           # follow logs
 sudo systemctl start halos-manage-certs.service       # force a refresh
 ```
 
-Auxiliary failures (public-CA publish, Cockpit override install) log
-`WARNING` and do not block the unit. A broken operator-supplied custom CA
+Auxiliary failures do not block the unit: a Cockpit override install failure
+logs `WARNING`, and a public-CA publish failure logs `ERROR` (it is the only
+signal that the served cert is missing or stale, since the `ca-download`
+healthcheck is liveness-only — see below). A broken operator-supplied custom CA
 in `/etc/halos/ca/` aborts the unit and therefore blocks
 `halos-core-containers.service` start.
 
@@ -137,6 +139,75 @@ read-only permissions. The marginal exposure (cockpit-ws group read on the
 second copy) is acceptable: the group exists specifically so cockpit-tls can
 read its private key.
 
+## Device-identifying CA name and the adoption freeze
+
+Each device's auto-CA carries a subject CN that names the device:
+
+    HaLOS Device CA (<hostname>)
+
+so several HaLOS devices' CAs are distinguishable in OS trust stores (Keychain
+Access, the iOS Profiles list, the Windows store) and in a Downloads folder —
+the pain is worst when an operator tries to delete a stale device's CA and sees
+several identical `HaLOS Device CA` rows. (Operator-supplied **custom** CAs keep
+whatever CN the operator set; only the auto-CA gets a device name.)
+
+### Why the name can go stale, and the adoption model
+
+The auto-CA is long-lived (20 y) and is deliberately **not** regenerated on a
+hostname change, because regenerating would orphan every trust anchor an
+operator already installed. But regenerating is *free of orphan risk until the
+CA has been downloaded at least once* — before first download nothing is
+installed anywhere to orphan. So the CN is kept fresh by regenerating while the
+CA is **unadopted**, and frozen permanently at **first download**.
+
+Adoption is one bit of state in a single file:
+
+    /var/lib/container-apps/halos-core-containers/certs/ca/adoption   # "pending" | "adopted"
+
+- **`pending`** — never downloaded. On each `halos-manage-certs` run, if the
+  resolved hostname differs from the CA's embedded name, the auto-CA is
+  regenerated with the current hostname (and the leaf re-signed). No installed
+  anchor exists yet, so this is safe.
+- **`adopted`** — the cert/profile was downloaded at least once (the
+  `ca-download` sidecar records it when it serves the file). The CN is now
+  **frozen**: a later hostname change leaves the name cosmetically stale, but
+  the installed anchor keeps working (TLS validates via the leaf's SANs, not the
+  CA's CN). This staleness is the accepted trade for never orphaning a trust
+  anchor.
+
+**Pre-feature CAs stay frozen with the generic name.** A CA created before this
+feature has the bare CN `HaLOS Device CA` and no sentinel. The first run that
+sees it stamps it `adopted` (frozen) — it *might* already be installed somewhere,
+so it is never regenerated. Such a device keeps the generic name; the page and
+trust-store search wording stay correct because they key on the stable
+`HaLOS Device CA` prefix.
+
+### Separation from the expiry / clock-skew self-heal
+
+The adoption gate governs **only** the hostname-CN refresh. The unrelated
+expiry / clock-skew self-heal regeneration (which rescues a CA generated with a
+bad first-boot clock on an RTC-less Pi) is **not** gated by
+adoption — it still fires for an adopted CA when the CA is expired or
+implausibly aged, and it picks up the current hostname in the new CN. An adopted
+CA is frozen against *rename-driven* refresh, not against self-heal.
+
+### Forcing a CN refresh after adoption (escape hatch)
+
+To make an adopted device pick up its current hostname in the CN — accepting
+that **every client that installed the old CA must reinstall and re-trust the
+new one** — reset the sentinel to `pending` and re-run cert management:
+
+```
+echo -n pending | sudo tee \
+  /var/lib/container-apps/halos-core-containers/certs/ca/adoption
+sudo systemctl start halos-manage-certs.service
+```
+
+The next run regenerates the auto-CA with the current hostname (a bare-CN legacy
+CA upgrades to a device-identifying name this way too), re-signs the leaf, and
+re-publishes. This is a one-file content edit — there is no need to delete
+`ca.crt`/`ca.key`.
+
 ## CA download endpoint
 
 The active CA is published at:
@@ -153,11 +224,21 @@ sidecar that serves the file returns it with:
 | Header                | Value                                       |
 |-----------------------|---------------------------------------------|
 | `Content-Type`        | `application/x-x509-ca-cert`                |
-| `Content-Disposition` | `attachment; filename="halos-ca.crt"`       |
+| `Content-Disposition` | `attachment; filename="halos-ca-<host>.crt"`|
 
 `attachment` is the load-bearing piece: it causes browsers to open the
 OS-level certificate install dialog instead of rendering the PEM as plain
-text.
+text. The saved filename is made device-specific (`halos-ca-<hostname>.crt`)
+client-side from `window.location.hostname`, so several devices' certs are
+distinguishable in a Downloads folder; the URL path itself never changes.
+
+**The sidecar is `busybox httpd` + small CGI scripts** (not nginx): serving the
+`.crt` or `.mobileconfig` records first download by flipping the adoption
+sentinel `pending → adopted` (the freeze described above), a per-request side
+effect stock nginx cannot express. The healthcheck is liveness-only — it never
+touches the cert path, so it cannot trip adoption, and a missing published cert
+is surfaced by `halos-manage-certs` at `ERROR` in the journal rather than by the
+container's health.
 
 ### Trust-install landing page
 

--- a/docs/solutions/2026-06-01-busybox-httpd-cgi-per-request-side-effects.md
+++ b/docs/solutions/2026-06-01-busybox-httpd-cgi-per-request-side-effects.md
@@ -1,0 +1,71 @@
+---
+title: "Use busybox httpd + CGI when a static-file sidecar must run a per-request side effect"
+date: 2026-06-01
+repo: halos-core-containers
+pr: https://github.com/halos-org/halos-core-containers/pull/181
+tags: [docker, busybox, httpd, cgi, nginx, sidecar, ca-download, pattern, gotcha, knowledge]
+---
+
+# Context
+
+The `ca-download` sidecar serves the device CA and its `.mobileconfig`. The
+device-identifying-CA feature (#176) needed it to record *first download* (to
+freeze the CA's CN). Stock `nginx:1.27-alpine` cannot run a deliberate
+per-request side effect — its only request-driven file write is `access_log`,
+the implicit-logging anti-pattern. We swapped nginx → `busybox httpd` + CGI so
+the cert/profile endpoints are shell scripts that emit the response and then
+write an explicit adoption sentinel. (~50 MB image → ~4 MB, and it stays in the
+repo's shell idiom.)
+
+# Pattern
+
+`httpd.conf` routes by suffix to a `/bin/sh` interpreter; the matched docroot
+file is the CGI:
+
+```
+*.crt:/bin/sh
+*.mobileconfig:/bin/sh
+```
+
+Run with `httpd -f -p 80 -u 65534:65534 -h /www -c /etc/httpd.conf`. A CGI emits
+`Status: NNN`, headers, a blank line, then the body (plain `\n` line endings are
+fine), and does its side effect last.
+
+Verified on `busybox:1.37` (digest `9532d8c3…`): CGI custom `Status:` (302/410/
+503) and arbitrary headers honored; `-u` drops to nobody after binding `:80`;
+`/dir` → `/dir/` is a native 302 with a **relative** `Location` (safe behind
+Traefik TLS — an absolute `http://` would downgrade the client).
+
+# Traps that cost time
+
+1. **CGI stdout is buffered by httpd.** A "flush body, then act" design gives
+   **no** torn-download/SIGPIPE protection for any payload that fits one socket
+   buffer (~64 KB) — every real cert flushes in one write and the side effect
+   runs regardless of client disconnect. SIGPIPE-abort only happens for payloads
+   larger than the buffer. Don't claim a "client confirmed receipt" guarantee
+   for small responses; design the side effect to be safe under premature firing.
+
+2. **Nested read-only bind mounts fail.** Mounting a file at `/www/ca/x` when
+   `/www/ca` is itself a `:ro` bind mount errors with *"read-only file system"*
+   (Docker can't create the mountpoint in the ro parent). busybox httpd has no
+   `alias`/rewrite, so the docroot tree must mirror the URL space exactly —
+   assemble **one** docroot directory and mount it once, rather than overlaying
+   CGI files into a separately-mounted asset dir.
+
+3. **`debian/rules` installs non-`.sh` files mode 0644.** CGIs named `*.crt` /
+   `*.mobileconfig` ship non-executable — which works **only** because busybox
+   runs them via the `/bin/sh` interpreter rule (the exec bit is not needed).
+   Confirmed empirically; don't rely on the tracked +x bit surviving packaging.
+
+4. **A single-file bind mount is inode-pinned at container start.** Every writer
+   (the in-container CGI *and* the host cert-manager) must write the file **in
+   place** (`printf > f`, truncate+rewrite), never tmp+mv — an inode swap
+   desyncs the container's view. The mount source must exist as a regular file
+   before `compose up`, or Docker creates a directory there.
+
+# Takeaway
+
+Reach for `busybox httpd` + CGI when a file-serving sidecar needs an explicit
+per-request action. Keep the docroot a single self-contained tree, write
+bind-mounted single files in place, and treat the side effect as fire-on-serve
+(not fire-on-receipt) for sub-buffer payloads.

--- a/docs/solutions/2026-06-01-inode-reuse-breaks-file-regeneration-tests.md
+++ b/docs/solutions/2026-06-01-inode-reuse-breaks-file-regeneration-tests.md
@@ -1,0 +1,53 @@
+---
+title: "Detect file regeneration by content hash, not inode — Linux reuses freed inode numbers"
+date: 2026-06-01
+repo: halos-core-containers
+pr: https://github.com/halos-org/halos-core-containers/pull/182
+tags: [testing, bash, openssl, inode, filesystem, ext4, overlay, ci, flaky, gotcha, knowledge]
+---
+
+# Context
+
+The CN-refresh gate in `halos-manage-certs` forces an auto-CA regeneration by
+deleting `ca.crt`/`ca.key` and re-running `halos_ca_ensure_auto`. A test asserted
+the regeneration happened by comparing the file's **inode** before and after:
+
+```bash
+ca_before=$(stat -c '%i' "$ca_crt")
+# ... rename + rerun ...
+[ "$(stat -c '%i' "$ca_crt")" != "$ca_before" ] || fail "CA must regenerate"
+```
+
+It passed on macOS and **failed in CI**.
+
+# Root cause
+
+The gate does `rm ca.crt` *before* recreating it. Linux `ext4` / overlayfs
+**reuses the just-freed inode number** for the next file created in the same
+directory — so the regenerated `ca.crt` got the *same* inode number (e.g.
+`6059049` both times), and the inequality check reported "not regenerated"
+even though the bytes were entirely new. macOS APFS does not reuse the number,
+so the bug was invisible locally.
+
+The neighbouring expiry-rotation test using the same inode technique passed in
+CI by accident: that path lets `ensure_auto` `mv` the new file over the existing
+one (no `rm` first), so the old inode is freed only *after* the new one is
+allocated — no reuse.
+
+# Fix
+
+Detect regeneration by **content**, not identity. For certs, fingerprint:
+
+```bash
+_ca_fp() { openssl x509 -in "$1" -noout -fingerprint -sha256; }
+```
+
+A regenerated CA has a new keypair → new fingerprint, on every filesystem.
+
+# Takeaway
+
+Inode equality is **not** a reliable "same file / different file" signal across
+a delete + recreate — Linux reuses inode numbers, and a macOS dev box will hide
+it. When a test means "the content changed", assert on the content (hash, or a
+field like the subject CN), not on `stat -c '%i'`. Reproduce filesystem-
+sensitive test failures in a `debian:trixie` container, not just on macOS.


### PR DESCRIPTION
Final unit of the device-identifying auto-CA work (#176) — operator-facing documentation, plus two durable engineering learnings.

## `docs/CERTS.md`
New **"Device-identifying CA name and the adoption freeze"** section covering:
- the `HaLOS Device CA (<hostname>)` CN and why it makes fleet devices distinguishable (install *and* deletion);
- the single `pending`/`adopted` sentinel, and *why* the name freezes at first download — the orphan-avoidance invariant (regenerating an installed anchor would break it);
- pre-feature bare-CN CAs staying frozen with the generic name (migration safety);
- the separation from the expiry/clock-skew self-heal regen (un-gated by adoption, picks up the current hostname);
- the **escape hatch** — reset the sentinel to `pending` to force a CN refresh, with the re-trust cost spelled out.

Also refreshes the **CA download endpoint** section for the busybox + CGI sidecar, the device-specific saved filename, and the liveness-only healthcheck, and corrects the publish-failure note to `ERROR`.

## `docs/solutions/`
Two reusable learnings surfaced during Units 1–2:
- **busybox httpd + CGI for per-request side effects** — the pattern and its traps (CGI stdout buffering defeats torn-download protection for sub-buffer payloads; nested read-only bind mounts fail; `debian/rules` ships CGIs 0644 which works only via the interpreter rule; single-file bind mounts need in-place writes).
- **Detect file regeneration by content hash, not inode** — Linux ext4/overlay reuses freed inode numbers across delete+recreate, so an inode comparison false-negatives; macOS APFS hides it. This was the Unit 2 CI failure.

Prose only — no tests. VERSION not bumped (docs are excluded from the bump check).

Closes #180
Closes #176