### PR TITLE
docs(certs): fix adoption sentinel path + download-header accuracy

### DIFF
--- a/docs/CERTS.md
+++ b/docs/CERTS.md
@@ -162,7 +162,7 @@ CA is **unadopted**, and frozen permanently at **first download**.
 
 Adoption is one bit of state in a single file:
 
-    /var/lib/container-apps/halos-core-containers/certs/ca/adoption   # "pending" | "adopted"
+    /var/lib/container-apps/halos-core-containers/data/halos-core-containers/certs/ca/adoption   # "pending" | "adopted"
 
 - **`pending`** — never downloaded. On each `halos-manage-certs` run, if the
   resolved hostname differs from the CA's embedded name, the auto-CA is
@@ -199,7 +199,7 @@ new one** — reset the sentinel to `pending` and re-run cert management:
 
 ```
 echo -n pending | sudo tee \
-  /var/lib/container-apps/halos-core-containers/certs/ca/adoption
+  /var/lib/container-apps/halos-core-containers/data/halos-core-containers/certs/ca/adoption
 sudo systemctl start halos-manage-certs.service
 ```
 
@@ -207,6 +207,10 @@ The next run regenerates the auto-CA with the current hostname (a bare-CN legacy
 CA upgrades to a device-identifying name this way too), re-signs the leaf, and
 re-publishes. This is a one-file content edit — there is no need to delete
 `ca.crt`/`ca.key`.
+
+The refresh only fires when the CA's embedded name differs from the current
+hostname: resetting to `pending` on a CA that already names the current host is
+a no-op (no regeneration, no re-trust cost).
 
 ## CA download endpoint
 
@@ -221,16 +225,18 @@ shared with the trust-install landing page at `https://<host>/ca/`.)
 Plain HTTP requests to the same path are redirected to HTTPS (308). The
 sidecar that serves the file returns it with:
 
-| Header                | Value                                       |
-|-----------------------|---------------------------------------------|
-| `Content-Type`        | `application/x-x509-ca-cert`                |
-| `Content-Disposition` | `attachment; filename="halos-ca-<host>.crt"`|
+| Header                | Value                                  |
+|-----------------------|----------------------------------------|
+| `Content-Type`        | `application/x-x509-ca-cert`           |
+| `Content-Disposition` | `attachment; filename="halos-ca.crt"`  |
 
 `attachment` is the load-bearing piece: it causes browsers to open the
 OS-level certificate install dialog instead of rendering the PEM as plain
-text. The saved filename is made device-specific (`halos-ca-<hostname>.crt`)
-client-side from `window.location.hostname`, so several devices' certs are
-distinguishable in a Downloads folder; the URL path itself never changes.
+text. The server always sends the static `filename="halos-ca.crt"`; the landing
+page then rewrites the *saved* name to a device-specific `halos-ca-<hostname>.crt`
+client-side (via the download link's `download` attribute, from
+`window.location.hostname`), so several devices' certs are distinguishable in a
+Downloads folder. The URL path itself never changes.
 
 **The sidecar is `busybox httpd` + small CGI scripts** (not nginx): serving the
 `.crt` or `.mobileconfig` records first download by flipping the adoption

--- a/docs/solutions/2026-06-01-busybox-httpd-cgi-per-request-side-effects.md
+++ b/docs/solutions/2026-06-01-busybox-httpd-cgi-per-request-side-effects.md
@@ -38,12 +38,14 @@ Traefik TLS — an absolute `http://` would downgrade the client).
 
 # Traps that cost time
 
-1. **CGI stdout is buffered by httpd.** A "flush body, then act" design gives
-   **no** torn-download/SIGPIPE protection for any payload that fits one socket
-   buffer (~64 KB) — every real cert flushes in one write and the side effect
-   runs regardless of client disconnect. SIGPIPE-abort only happens for payloads
-   larger than the buffer. Don't claim a "client confirmed receipt" guarantee
-   for small responses; design the side effect to be safe under premature firing.
+1. **CGI stdout is buffered by httpd.** A "flush body, then act" design does
+   **not** protect against premature firing for any payload that fits one socket
+   buffer (~64 KB): the body flushes in a single write that completes before any
+   client disconnect is observable, so the side effect runs even if the client
+   aborted mid-transfer. A broken-pipe SIGPIPE can abort the side effect only for
+   payloads *larger* than the buffer (every real cert is smaller). Don't claim a
+   "client confirmed receipt" guarantee for small responses; design the side
+   effect to be safe under premature firing.
 
 2. **Nested read-only bind mounts fail.** Mounting a file at `/www/ca/x` when
    `/www/ca` is itself a `:ro` bind mount errors with *"read-only file system"*


### PR DESCRIPTION
Fixes the valid review findings from #184 (device-identifying CA docs). Docs only.

## F1 — wrong adoption sentinel path (was breaking)
`docs/CERTS.md` gave the sentinel as `.../halos-core-containers/certs/ca/adoption` in both the display block and the escape-hatch `tee` command. The real path is `.../halos-core-containers/**data/halos-core-containers/**certs/ca/adoption` — `CONTAINER_DATA_ROOT` (from `env.defaults`) already ends in `/data`, and `AUTO_CA_DIR=${CONTAINER_DATA_ROOT}/${PACKAGE_NAME}/certs/ca`. As written, the escape-hatch command wrote `pending` to a nonexistent path and silently no-op'd. Now matches the other (correct) paths in the same doc.

## F2 — Content-Disposition table was misleading
The table showed `filename="halos-ca-<host>.crt"`, but the CGI sends the **static** `filename="halos-ca.crt"`; the device-specific name is applied client-side via the `download` attribute. The table now shows the real header, with the client-side rename explained in prose (so `curl -I` matches the doc).

## F3 / F4 — wording
- Note the escape hatch is a **no-op** when the CA already names the current host (the gate fires only on a name mismatch).
- Sharpen the busybox-CGI solutions entry's premature-firing wording (it read ambiguously about whether SIGPIPE can abort the side effect for small payloads).

Verified the corrected path against `env.defaults` + `halos-manage-certs` and the pre-existing correct paths in CERTS.md. The #179/Unit-3 review (PR #183) found only an optional cosmetic nit — not included here.

Refs #176