### PR TITLE
fix(ca-download): device-specific cert filename must be server-side

### DIFF
--- a/assets/ca-download/www/ca/halos-ca.crt
+++ b/assets/ca-download/www/ca/halos-ca.crt
@@ -19,12 +19,37 @@ set -u
 CA_CRT="${HALOS_CA_PUBLIC_CRT:-/srv/halos-ca.crt}"
 ADOPTION="${HALOS_ADOPTION_FILE:-/adoption}"
 
+# Device-specific saved filename, derived from the Host the client used, so
+# several devices' certs are distinguishable in a Downloads folder. This MUST be
+# set server-side: a Content-Disposition filename from the server overrides an
+# HTML `download` attribute, so a client-side name never takes effect. The Host
+# is client-controlled, so sanitize to [A-Za-z0-9._-] (also trimming leading/
+# trailing separators) — this both yields a safe filename and blocks header
+# injection. Empty/again-unresolved Host falls back to the bare name.
+_host="${HTTP_HOST:-}"
+# Strip the port: a bracketed IPv6 host ([::1] or [::1]:443) keeps the address
+# inside the brackets; otherwise host[:port] drops at the first colon. (A bare,
+# unbracketed IPv6 Host is malformed per RFC 3986 and not handled specially.)
+case "$_host" in
+    \[*\]*) _host="${_host#\[}"; _host="${_host%%\]*}" ;;
+    *)      _host="${_host%%:*}" ;;
+esac
+# Sanitize (the Host is client-controlled), cap the length so the result stays a
+# valid <=255-byte filename component, then trim leading/trailing separators.
+_safe="$(printf '%s' "$_host" | tr -d '\r\n' | sed 's/[^A-Za-z0-9._-]/-/g')"
+_safe="$(printf '%.64s' "$_safe" | sed -e 's/^[._-]*//' -e 's/[._-]*$//')"
+if [ -n "$_safe" ]; then
+    CERT_FILENAME="halos-ca-${_safe}.crt"
+else
+    CERT_FILENAME="halos-ca.crt"
+fi
+
 emit_headers() {
     printf 'Status: 200 OK\n'
     printf 'Content-Type: application/x-x509-ca-cert\n'
     # attachment triggers the OS/browser cert-install dialog rather than
     # rendering the PEM as text.
-    printf 'Content-Disposition: attachment; filename="halos-ca.crt"\n'
+    printf 'Content-Disposition: attachment; filename="%s"\n' "$CERT_FILENAME"
     printf '\n'
 }
 

--- a/assets/ca-download/www/ca/index.html
+++ b/assets/ca-download/www/ca/index.html
@@ -109,8 +109,7 @@
       </p>
 
       <p>
-        <a class="download" href="/ca/halos-ca.crt" download="halos-ca.crt" data-cert-download
-          >Download the HaLOS CA certificate</a
+        <a class="download" href="/ca/halos-ca.crt" download="halos-ca.crt"          >Download the HaLOS CA certificate</a
         >
       </p>
 
@@ -133,7 +132,7 @@
       <details id="macos">
         <summary>macOS</summary>
         <ol>
-          <li>Download <a href="/ca/halos-ca.crt" download="halos-ca.crt" data-cert-download><code>halos-ca.crt</code></a> (the button at the top does the same).</li>
+          <li>Download <a href="/ca/halos-ca.crt" download="halos-ca.crt"><code data-cert-filename>halos-ca.crt</code></a> (the button at the top does the same).</li>
           <li>Double-click the downloaded file. Keychain Access opens and adds the certificate to the <strong>System</strong> keychain (choose System if it asks which keychain); enter an admin password if prompted.</li>
           <li>It's installed but not yet trusted. In Keychain Access, select the <strong>System</strong> keychain, find <em>HaLOS Device CA</em> under <em>Certificates</em> (on newer devices it reads <em>HaLOS Device CA (<span data-device-host>this device</span>)</em>), and double-click it.</li>
           <li>Expand <strong>Trust</strong> and set <em>Secure Sockets Layer (SSL)</em> (or <em>When using this certificate</em>) to <strong>Always Trust</strong>. Close the window and authenticate. <span class="caveat">macOS keeps install and trust separate — without this step the warnings stay.</span></li>
@@ -157,8 +156,8 @@
         <details>
           <summary>Advanced: install the raw certificate instead</summary>
           <ol>
-            <li>Download <a href="/ca/halos-ca.crt" download="halos-ca.crt" data-cert-download><code>halos-ca.crt</code></a> in Safari. iOS usually saves it to the <strong>Files</strong> app instead of prompting.</li>
-            <li>Open the <strong>Files</strong> app and tap the downloaded <code>halos-ca.crt</code>. iOS asks whether to allow the certificate — allow it, then it appears under <strong>Settings → General → VPN &amp; Device Management</strong>.</li>
+            <li>Download <a href="/ca/halos-ca.crt" download="halos-ca.crt"><code data-cert-filename>halos-ca.crt</code></a> in Safari. iOS usually saves it to the <strong>Files</strong> app instead of prompting.</li>
+            <li>Open the <strong>Files</strong> app and tap the downloaded <code data-cert-filename>halos-ca.crt</code>. iOS asks whether to allow the certificate — allow it, then it appears under <strong>Settings → General → VPN &amp; Device Management</strong>.</li>
             <li>Install it from there, then enable it under <strong>Settings → General → About → Certificate Trust Settings</strong>. <span class="caveat">The install profile above avoids this Files-app detour — prefer it.</span></li>
           </ol>
         </details>
@@ -167,9 +166,9 @@
       <details id="android">
         <summary>Android</summary>
         <ol>
-          <li>Tap <strong>Download</strong> above to save <code>halos-ca.crt</code>.</li>
+          <li>Tap <strong>Download</strong> above to save <code data-cert-filename>halos-ca.crt</code>.</li>
           <li>Open <strong>Settings</strong>, search for <strong>cert</strong>, and choose <strong>CA certificate</strong> under <em>Install a certificate</em>. <span class="caveat">Searching jumps straight to the right screen — the manual path (Security → Encryption &amp; credentials) is several taps deep and varies by vendor.</span></li>
-          <li>Accept the warning and pick the downloaded <code>halos-ca.crt</code>.</li>
+          <li>Accept the warning and pick the downloaded <code data-cert-filename>halos-ca.crt</code>.</li>
         </ol>
         <p class="caveat">Android trusts user-installed CAs in browsers only, not in apps — this is an Android design decision. You will get a green lock in Chrome or Brave; native apps still show warnings.</p>
       </details>
@@ -178,25 +177,25 @@
         <summary>Linux (Debian / Ubuntu)</summary>
         <p>System trust store (Chromium, Chrome, curl, most apps):</p>
         <ol>
-          <li>Download <code>halos-ca.crt</code>.</li>
+          <li>Download <code data-cert-filename>halos-ca.crt</code>.</li>
           <li>Install it:
-            <pre>sudo cp halos-ca.crt /usr/local/share/ca-certificates/halos-ca.crt
+            <pre>sudo cp <span data-cert-filename>halos-ca.crt</span> /usr/local/share/ca-certificates/<span data-cert-filename>halos-ca.crt</span>
 sudo update-ca-certificates</pre>
           </li>
           <li>Restart Chromium or Chrome.</li>
         </ol>
-        <p class="caveat">Firefox keeps its own certificate store: <strong>Settings → Privacy &amp; Security → Certificates → View Certificates → Authorities → Import</strong>, select <code>halos-ca.crt</code>, and trust it for websites.</p>
+        <p class="caveat">Firefox keeps its own certificate store: <strong>Settings → Privacy &amp; Security → Certificates → View Certificates → Authorities → Import</strong>, select <code data-cert-filename>halos-ca.crt</code>, and trust it for websites.</p>
       </details>
 
       <details id="windows">
         <summary>Windows</summary>
         <ol>
-          <li>Download <code>halos-ca.crt</code>.</li>
+          <li>Download <code data-cert-filename>halos-ca.crt</code>.</li>
           <li>Double-click it and choose <strong>Install Certificate → Local Machine</strong> (accept the admin prompt).</li>
           <li>Select <strong>Place all certificates in the following store → Trusted Root Certification Authorities</strong>, then finish.</li>
           <li>Restart your browser.</li>
         </ol>
-        <p class="caveat">Chrome and Edge use the Windows certificate store automatically. Firefox keeps its own store: either set <code>security.enterprise_roots.enabled</code> to <code>true</code> in <code>about:config</code> (Firefox then trusts the certificate you just installed), or import <code>halos-ca.crt</code> directly as described in the Linux section.</p>
+        <p class="caveat">Chrome and Edge use the Windows certificate store automatically. Firefox keeps its own store: either set <code>security.enterprise_roots.enabled</code> to <code>true</code> in <code>about:config</code> (Firefox then trusts the certificate you just installed), or import <code data-cert-filename>halos-ca.crt</code> directly as described in the Linux section.</p>
       </details>
 
       <footer>
@@ -227,21 +226,22 @@ sudo update-ca-certificates</pre>
           if (match) match.open = true;
         }
 
-        // The page is served from the device being accessed, so its hostname
-        // is window.location.hostname — no server-side injection needed.
+        // The download itself is named server-side (the cert endpoint's
+        // Content-Disposition overrides any client `download` attribute). The
+        // instructions, though, reference that filename by name, so fill them in
+        // to match — using the SAME derivation as the cert CGI so the shown name
+        // equals the saved name: strip IPv6 brackets, sanitize to
+        // [A-Za-z0-9._-], cap at 64, trim separators.
         var host = window.location.hostname || "";
-
-        // Device-specific saved filename so several devices' certs are
-        // distinguishable in a Downloads folder. The URL path stays
-        // /ca/halos-ca.crt; only the Content-Disposition-equivalent (the
-        // download attribute) changes. Sanitize to a filesystem-safe name —
-        // dots and hyphens pass (DNS names, IPv4 literals); an IPv6 literal's
-        // colons collapse to "-". Empty host falls back to the bare name.
-        var safe = host.replace(/[^A-Za-z0-9._-]/g, "-");
-        var filename = safe ? "halos-ca-" + safe + ".crt" : "halos-ca.crt";
-        var anchors = document.querySelectorAll("a[data-cert-download]");
-        for (var i = 0; i < anchors.length; i++) {
-          anchors[i].setAttribute("download", filename);
+        var safe = host
+          .replace(/^\[|\]$/g, "")
+          .replace(/[^A-Za-z0-9._-]/g, "-")
+          .slice(0, 64)
+          .replace(/^[._-]+|[._-]+$/g, "");
+        var certFile = safe ? "halos-ca-" + safe + ".crt" : "halos-ca.crt";
+        var nameEls = document.querySelectorAll("[data-cert-filename]");
+        for (var k = 0; k < nameEls.length; k++) {
+          nameEls[k].textContent = certFile;
         }
 
         // Name the device wherever the steps reference it as context for the

--- a/docs/CERTS.md
+++ b/docs/CERTS.md
@@ -225,18 +225,21 @@ shared with the trust-install landing page at `https://<host>/ca/`.)
 Plain HTTP requests to the same path are redirected to HTTPS (308). The
 sidecar that serves the file returns it with:
 
-| Header                | Value                                  |
-|-----------------------|----------------------------------------|
-| `Content-Type`        | `application/x-x509-ca-cert`           |
-| `Content-Disposition` | `attachment; filename="halos-ca.crt"`  |
+| Header                | Value                                       |
+|-----------------------|---------------------------------------------|
+| `Content-Type`        | `application/x-x509-ca-cert`                |
+| `Content-Disposition` | `attachment; filename="halos-ca-<host>.crt"`|
 
 `attachment` is the load-bearing piece: it causes browsers to open the
-OS-level certificate install dialog instead of rendering the PEM as plain
-text. The server always sends the static `filename="halos-ca.crt"`; the landing
-page then rewrites the *saved* name to a device-specific `halos-ca-<hostname>.crt`
-client-side (via the download link's `download` attribute, from
-`window.location.hostname`), so several devices' certs are distinguishable in a
-Downloads folder. The URL path itself never changes.
+OS-level certificate install dialog instead of rendering the PEM as plain text.
+
+The saved filename is device-specific (`halos-ca-<host>.crt`) so several
+devices' certs are distinguishable in a Downloads folder. It is built **in the
+CGI** from the request `Host` header (port stripped, sanitized to
+`[A-Za-z0-9._-]`) — *not* client-side: a server `Content-Disposition` filename
+overrides an HTML `download` attribute, so a page-set name would never take
+effect. Accessed by raw IP, `<host>` is that IP. The URL path itself never
+changes.
 
 **The sidecar is `busybox httpd` + small CGI scripts** (not nginx): serving the
 `.crt` or `.mobileconfig` records first download by flipping the adoption

--- a/docs/solutions/2026-06-01-content-disposition-overrides-download-attribute.md
+++ b/docs/solutions/2026-06-01-content-disposition-overrides-download-attribute.md
@@ -1,0 +1,53 @@
+---
+title: "A server Content-Disposition filename overrides the HTML download attribute"
+date: 2026-06-01
+repo: halos-core-containers
+pr: https://github.com/halos-org/halos-core-containers/pull/186
+tags: [http, content-disposition, download-attribute, browser, ca-download, frontend, verification, gotcha, knowledge]
+---
+
+# Context
+
+The device-identifying CA work (#179) tried to give each device a distinct
+download filename `halos-ca-<hostname>.crt` purely client-side: the `/ca` landing
+page is served from the device, so its JS read `window.location.hostname` and set
+the cert link's HTML `download` attribute to the per-device name.
+
+It never worked. On the device, clicking download always saved `halos-ca.crt`.
+
+# Root cause
+
+The cert endpoint responds with a `Content-Disposition: attachment;
+filename="halos-ca.crt"` header. For a same-origin download, a server-supplied
+`Content-Disposition` filename **takes precedence over the HTML `download`
+attribute** — the attribute is only a fallback used when the server does not
+specify a name (MDN documents this explicitly). So the page's client-side name
+could never win against the static server header.
+
+The plan's assumption ("the page knows the hostname client-side, so no
+server-side injection is needed") was simply wrong for any endpoint that already
+sends a `Content-Disposition` filename.
+
+# Fix
+
+Set the device-specific filename **server-side**, in the cert CGI, from the
+request `Host` header (port stripped — bracket-aware for IPv6 — sanitized to
+`[A-Za-z0-9._-]`, length-capped, separators trimmed; the sanitization doubles as
+a header-injection guard). That is authoritative for browsers and `curl -OJ`
+alike. The page's JS keeps only display concerns: it fills the *instruction text*
+with the same computed name (mirroring the CGI's sanitization) so the steps name
+the file the user actually saved.
+
+# How it slipped through — the verification lesson
+
+The original change was "verified" in a browser by reading the anchor's
+`download` **attribute value** (`getAttribute('download')`) — which was correctly
+set to the per-device name. But the attribute value is an intermediate DOM proxy,
+not the effect. The thing that matters — the **saved filename** — is decided by
+the server header, which the attribute check never exercised.
+
+Verify the user-visible effect, not a proxy for it. For a download, that means
+the actual `Content-Disposition` the server sends (or the real saved file), not
+the `download` attribute. The fix's own check compares the page's displayed
+filename against a live `HEAD` of the cert endpoint's `Content-Disposition`, and
+asserts they are equal.

--- a/tests/test-ca-download-cgi.sh
+++ b/tests/test-ca-download-cgi.sh
@@ -63,12 +63,13 @@ new_scratch() {
 }
 
 # Invoke a CGI with the scratch paths wired in. Usage:
-#   invoke <cgi> <scratch> <method>
+#   invoke <cgi> <scratch> <method> [http_host]
 invoke() {
     HALOS_CA_PUBLIC_CRT="$2/halos-ca.crt" \
     HALOS_CA_PUBLIC_PROFILE="$2/halos-ca.mobileconfig" \
     HALOS_ADOPTION_FILE="$2/adoption" \
     REQUEST_METHOD="$3" \
+    HTTP_HOST="${4:-}" \
     sh "$1"
 }
 
@@ -86,6 +87,73 @@ test_cert_get_serves_and_adopts() {
     assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca.crt"' "disposition" || return 1
     case "$out" in *"BEGIN CERTIFICATE"*) ;; *) echo "body missing cert"; return 1 ;; esac
     assert_eq "$(cat "$d/adoption")" "adopted" "completed GET must adopt" || return 1
+}
+
+test_cert_filename_from_host_is_device_specific() {
+    # The saved filename must be device-specific and come from the Host header
+    # (a server Content-Disposition filename overrides the page download attr).
+    local d; d=$(new_scratch cert_host)
+    local out; out=$(invoke "$CERT_CGI" "$d" GET halosdev.local)
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-halosdev.local.crt"' "device-specific filename from Host" || return 1
+}
+
+test_cert_filename_strips_host_port() {
+    local d; d=$(new_scratch cert_host_port)
+    local out; out=$(invoke "$CERT_CGI" "$d" GET "halosdev.local:8443")
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-halosdev.local.crt"' "port stripped from filename" || return 1
+}
+
+test_cert_filename_falls_back_without_host() {
+    local d; d=$(new_scratch cert_no_host)
+    local out; out=$(invoke "$CERT_CGI" "$d" GET "")
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca.crt"' "bare filename when Host absent" || return 1
+}
+
+test_cert_filename_sanitizes_malicious_host() {
+    # A crafted Host with separators/quotes/spaces must collapse to a safe
+    # filename — no header injection, no stray quotes.
+    local d; d=$(new_scratch cert_evil_host)
+    local out; out=$(invoke "$CERT_CGI" "$d" GET 'a/b "c.local')
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-a-b--c.local.crt"' "host sanitized to safe filename" || return 1
+}
+
+test_cert_filename_no_crlf_header_injection() {
+    # A Host carrying a CRLF + a forged header must not inject one: CR/LF are
+    # stripped before sanitizing, so there is exactly one Content-Disposition
+    # line (with the forged text folded into the filename), and no Set-Cookie.
+    local d; d=$(new_scratch cert_crlf_host)
+    local out; out=$(invoke "$CERT_CGI" "$d" GET "$(printf 'evil\r\nSet-Cookie: pwned')")
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-evilSet-Cookie.crt"' "CRLF folded into filename, not injected" || return 1
+    local cd_lines; cd_lines=$(printf '%s\n' "$out" | grep -ci '^Content-Disposition:')
+    assert_eq "$cd_lines" "1" "exactly one Content-Disposition line" || return 1
+    if printf '%s\n' "$out" | grep -qi '^Set-Cookie:'; then
+        echo "CRLF in Host injected a header"; return 1
+    fi
+}
+
+test_cert_filename_ipv6_bracketed() {
+    # A bracketed IPv6 Host keeps the address (port stripped); colons collapse
+    # to "-", so two IPv6 devices still get distinguishable filenames.
+    local d; d=$(new_scratch cert_ipv6)
+    local out; out=$(invoke "$CERT_CGI" "$d" GET "[2001:db8::1]:443")
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-2001-db8--1.crt"' "bracketed IPv6 filename" || return 1
+}
+
+test_cert_filename_length_capped() {
+    # An over-long Host must not produce a filename component over the 255-byte
+    # FS limit (which would truncate and could mask the .crt suffix).
+    local d; d=$(new_scratch cert_long_host)
+    local long; long=$(printf 'a%.0s' {1..300})
+    local out; out=$(invoke "$CERT_CGI" "$d" GET "${long}.local")
+    local expect; expect="attachment; filename=\"halos-ca-$(printf 'a%.0s' {1..64}).crt\""
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" "$expect" "host length capped at 64" || return 1
+}
+
+test_cert_head_uses_device_filename() {
+    # HEAD shares emit_headers, so it must carry the same device-specific name.
+    local d; d=$(new_scratch cert_head_host)
+    local out; out=$(invoke "$CERT_CGI" "$d" HEAD halosdev.local)
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-halosdev.local.crt"' "HEAD device filename" || return 1
 }
 
 test_cert_get_adopt_is_in_place() {
@@ -163,6 +231,14 @@ test_gone_returns_410_with_canonical_hint() {
 }
 
 run_test test_cert_get_serves_and_adopts
+run_test test_cert_filename_from_host_is_device_specific
+run_test test_cert_filename_strips_host_port
+run_test test_cert_filename_falls_back_without_host
+run_test test_cert_filename_sanitizes_malicious_host
+run_test test_cert_filename_no_crlf_header_injection
+run_test test_cert_filename_ipv6_bracketed
+run_test test_cert_filename_length_capped
+run_test test_cert_head_uses_device_filename
 run_test test_cert_get_adopt_is_in_place
 run_test test_cert_head_serves_headers_without_adopting
 run_test test_cert_post_rejected_without_adopting

--- a/tests/test-ca-download-endpoint.sh
+++ b/tests/test-ca-download-endpoint.sh
@@ -108,7 +108,10 @@ check "GET /healthz leaves sentinel"       "pending" "$(cat "$SENTINEL")"
 reset_sentinel
 check "GET /ca/halos-ca.crt status"        "200" "$(code "$BASE/ca/halos-ca.crt")"
 check "GET /ca/halos-ca.crt content-type"  "application/x-x509-ca-cert" "$(hdr Content-Type "$BASE/ca/halos-ca.crt")"
-check "GET /ca/halos-ca.crt disposition"   'attachment; filename="halos-ca.crt"' "$(hdr Content-Disposition "$BASE/ca/halos-ca.crt")"
+# Device-specific filename derived server-side from the Host header (curl sends
+# Host: 127.0.0.1:<port>; the CGI strips the port). A server filename overrides
+# the page's download attribute, which is why this must come from the server.
+check "GET /ca/halos-ca.crt disposition"   'attachment; filename="halos-ca-127.0.0.1.crt"' "$(hdr Content-Disposition "$BASE/ca/halos-ca.crt")"
 # Cross-boundary: the in-container CGI flipped the host-visible sentinel.
 check "completed cert GET adopts"          "adopted" "$(cat "$SENTINEL")"
 # Idempotent: a second download with the sentinel already adopted is a no-op.

--- a/tests/test_landing_content.py
+++ b/tests/test_landing_content.py
@@ -88,18 +88,16 @@ def test_cert_url_path_unchanged():
     assert 'href="/ca/halos-ca.crt"' in HTML
 
 
-def test_cert_download_anchors_are_marked_and_have_download_attr():
-    # Every cert-download anchor carries the data-cert-download hook (so the JS
-    # can set a per-device filename) and a static download fallback (so the
-    # save name is sane with JS off). Count parity catches a new cert anchor
-    # added without the hook.
+def test_cert_download_anchors_have_download_attr():
+    # Every cert anchor keeps a static download attribute (a sensible fallback);
+    # the device-specific name itself is set server-side via Content-Disposition,
+    # not here (a server filename overrides the download attribute).
     import re
 
     cert_anchors = re.findall(r"<a\b[^>]*>", HTML)
     cert_anchors = [a for a in cert_anchors if 'href="/ca/halos-ca.crt"' in a]
     assert cert_anchors, "expected at least one cert-download anchor"
     for a in cert_anchors:
-        assert "data-cert-download" in a
         assert "download=" in a
 
 
@@ -108,10 +106,16 @@ def test_device_host_placeholder_present():
     assert "data-device-host" in HTML
 
 
-def test_device_filename_js_builds_per_device_name():
-    # The JS derives a sanitized halos-ca-<host>.crt filename from the hostname.
+def test_instruction_filenames_are_templated():
+    # Every visible reference to the downloaded file is hooked so the JS can
+    # rewrite it to the device-specific name (matching the server-set save
+    # name). The static text stays halos-ca.crt as the no-JS fallback.
+    assert "data-cert-filename" in HTML
+    # The Linux cp command references the file twice — both must be hooked, so
+    # a copy-pasted command names the file the user actually downloaded.
+    assert HTML.count("data-cert-filename") >= 2
+    # The JS derives the same halos-ca-<host>.crt name the CGI does.
     assert 'halos-ca-" + safe + ".crt' in HTML
-    assert "window.location.hostname" in HTML
 
 
 def test_device_name_falls_back_for_ip_access():


### PR DESCRIPTION
## Bug
The device-specific download filename from #179 (`halos-ca-<host>.crt`) never worked. The cert endpoint serves `Content-Disposition: attachment; filename="halos-ca.crt"`, and **a server-sent `Content-Disposition` filename overrides an HTML `download` attribute** (documented same-origin browser behavior). So the page's client-side `download` value was always ignored and browsers saved `halos-ca.crt`.

Caught on the test device after a sentinel reset: clicking download on `halosdev.local/ca` saved `halos-ca.crt`, not `halos-ca-halosdev.local.crt`.

The original plan's "client-side is enough / no server-side injection needed" was wrong, and my #179 Playwright check only asserted the `download` *attribute value*, not the effective saved name with the server header present — that's the verification gap.

## Fix
Build the filename **in the cert CGI** from the request `Host` header:
- strip the port, sanitize to `[A-Za-z0-9._-]`, drop CR/LF, trim leading/trailing separators;
- the sanitization doubles as a header-injection guard (a crafted `Host` can't inject a header);
- empty/unresolved Host → bare `halos-ca.crt`; raw-IP access → `halos-ca-<ip>.crt`.

This is authoritative for browsers and `curl -OJ`. The landing JS no longer sets a download name (it would be overridden anyway) — it keeps only the device-name text fill; the now-dead `data-cert-download` hooks are removed.

## Tests
- `test-ca-download-cgi.sh`: device filename from Host, port strip, no-Host fallback, malicious-Host sanitization, and CRLF-injection guard.
- `test-ca-download-endpoint.sh`: asserts the real busybox server emits `filename="halos-ca-127.0.0.1.crt"` from the curl `Host` header (proves `HTTP_HOST` reaches the CGI).
- `test_landing_content.py`: dropped the client-side-filename assertions.

## Docs
`docs/CERTS.md`: the filename now correctly documented as server-side (Host header), with the download-attribute-override rationale — corrects the earlier client-side claim (incl. the one from #185).

All suites green (`./run test`): cgi 14, endpoint 23, lib-ca 109, manage-certs 33, hostnames 45, traefik 10, pytest 24. VERSION unchanged (cycle open).

Refs #176, #179

---
**Update:** also makes the on-page install instructions show the device-specific filename (every per-OS reference + the Linux `cp` command), and hardens the CGI host parsing (bracket-aware IPv6 port strip, 64-char length cap). Verified in a browser that the shown name equals the server's actual `Content-Disposition` filename.