### PR TITLE
fix(ca-download): cert download filename from the CA's CN

### DIFF
--- a/assets/ca-download/www/ca/halos-ca.crt
+++ b/assets/ca-download/www/ca/halos-ca.crt
@@ -19,29 +19,26 @@ set -u
 CA_CRT="${HALOS_CA_PUBLIC_CRT:-/srv/halos-ca.crt}"
 ADOPTION="${HALOS_ADOPTION_FILE:-/adoption}"
 
-# Device-specific saved filename, derived from the Host the client used, so
-# several devices' certs are distinguishable in a Downloads folder. This MUST be
-# set server-side: a Content-Disposition filename from the server overrides an
-# HTML `download` attribute, so a client-side name never takes effect. The Host
-# is client-controlled, so sanitize to [A-Za-z0-9._-] (also trimming leading/
-# trailing separators) — this both yields a safe filename and blocks header
-# injection. Empty/again-unresolved Host falls back to the bare name.
-_host="${HTTP_HOST:-}"
-# Strip the port: a bracketed IPv6 host ([::1] or [::1]:443) keeps the address
-# inside the brackets; otherwise host[:port] drops at the first colon. (A bare,
-# unbracketed IPv6 Host is malformed per RFC 3986 and not handled specially.)
-case "$_host" in
-    \[*\]*) _host="${_host#\[}"; _host="${_host%%\]*}" ;;
-    *)      _host="${_host%%:*}" ;;
-esac
-# Sanitize (the Host is client-controlled), cap the length so the result stays a
-# valid <=255-byte filename component, then trim leading/trailing separators.
-_safe="$(printf '%s' "$_host" | tr -d '\r\n' | sed 's/[^A-Za-z0-9._-]/-/g')"
-_safe="$(printf '%.64s' "$_safe" | sed -e 's/^[._-]*//' -e 's/[._-]*$//')"
-if [ -n "$_safe" ]; then
-    CERT_FILENAME="halos-ca-${_safe}.crt"
-else
-    CERT_FILENAME="halos-ca.crt"
+# Device-specific saved filename, published by the cert-manager from the active
+# CA's subject CN (so the file is named after the cert's identity, not how the
+# page was reached). This MUST be set server-side: a Content-Disposition
+# filename overrides an HTML `download` attribute, so a page-set name never
+# takes effect. busybox has no openssl to read the CN, so the name is read from
+# a file the cert-manager writes. Validate it to a known-safe shape; fall back
+# to the generic name otherwise.
+NAME_FILE="${HALOS_CA_DOWNLOAD_NAME:-/srv/download-filename}"
+CERT_FILENAME="halos-ca.crt"
+if [ -f "$NAME_FILE" ]; then
+    _n="$(tr -d '\r\n' < "$NAME_FILE")"
+    case "$_n" in
+        halos-ca.crt) CERT_FILENAME="$_n" ;;
+        # require an alphanumeric right after the prefix (rejects halos-ca-.crt)
+        halos-ca-[A-Za-z0-9]*.crt)
+            case "$_n" in
+                *[!A-Za-z0-9._-]*) ;;
+                *)                 CERT_FILENAME="$_n" ;;
+            esac ;;
+    esac
 fi
 
 emit_headers() {

--- a/assets/ca-download/www/ca/index.html
+++ b/assets/ca-download/www/ca/index.html
@@ -226,34 +226,28 @@ sudo update-ca-certificates</pre>
           if (match) match.open = true;
         }
 
-        // The download itself is named server-side (the cert endpoint's
-        // Content-Disposition overrides any client `download` attribute). The
-        // instructions, though, reference that filename by name, so fill them in
-        // to match — using the SAME derivation as the cert CGI so the shown name
-        // equals the saved name: strip IPv6 brackets, sanitize to
-        // [A-Za-z0-9._-], cap at 64, trim separators.
-        var host = window.location.hostname || "";
-        var safe = host
-          .replace(/^\[|\]$/g, "")
-          .replace(/[^A-Za-z0-9._-]/g, "-")
-          .slice(0, 64)
-          .replace(/^[._-]+|[._-]+$/g, "");
-        var certFile = safe ? "halos-ca-" + safe + ".crt" : "halos-ca.crt";
-        var nameEls = document.querySelectorAll("[data-cert-filename]");
-        for (var k = 0; k < nameEls.length; k++) {
-          nameEls[k].textContent = certFile;
+        // The cert is named server-side from the CA's subject CN (a
+        // Content-Disposition filename overrides any client `download`
+        // attribute). Learn that name authoritatively with one HEAD, then fill
+        // both the filename references and the device-name context from it, so
+        // the page always shows the exact file the user saves and the name the
+        // trust store displays. HEAD does not record adoption. With JS off (or
+        // if the request fails) the static "halos-ca.crt" / "this device"
+        // fallbacks stand.
+        function fill(sel, text) {
+          var els = document.querySelectorAll(sel);
+          for (var i = 0; i < els.length; i++) els[i].textContent = text;
         }
-
-        // Name the device wherever the steps reference it as context for the
-        // trust-store entry. The CA's CN embeds the device's DNS hostname, never
-        // an IP literal, so fall back to "this device" when accessed by raw IP
-        // (or with no hostname) rather than showing a misleading address.
-        var isIp = /^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.indexOf(":") !== -1;
-        var label = host && !isIp ? host : "this device";
-        var hosts = document.querySelectorAll("[data-device-host]");
-        for (var j = 0; j < hosts.length; j++) {
-          hosts[j].textContent = label;
-        }
+        fetch("/ca/halos-ca.crt", { method: "HEAD" })
+          .then(function (r) {
+            var cd = r.headers.get("Content-Disposition") || "";
+            var m = cd.match(/filename="([^"]+)"/);
+            var file = m ? m[1] : "halos-ca.crt";
+            fill("[data-cert-filename]", file);
+            var hm = file.match(/^halos-ca-(.+)\.crt$/);
+            fill("[data-device-host]", hm ? hm[1] : "this device");
+          })
+          .catch(function () {});
       })();
     </script>
   </body>

--- a/assets/halos-manage-certs
+++ b/assets/halos-manage-certs
@@ -168,6 +168,22 @@ if ! halos_ca_publish_mobileconfig "${HALOS_CA_ACTIVE_CRT}" "${PUBLIC_CA_DIR}" "
     echo "WARNING: failed to refresh Apple .mobileconfig at ${PUBLIC_CA_DIR}/halos-ca.mobileconfig; the /ca/halos-ca.mobileconfig endpoint may serve stale or no profile until the next successful run." >&2
 fi
 
+# Publish the device-specific download filename (derived from the active CA's
+# subject CN) next to the public PEM, so the ca-download sidecar can name the
+# download after the cert's identity. busybox has no openssl to read the CN, so
+# the name is computed here and read by the CGI. Auxiliary: a failure leaves the
+# sidecar to fall back to the generic halos-ca.crt.
+# Write atomically (stage + mv) so a per-request CGI read never sees the new CA
+# alongside a half-written or stale name — matching halos_ca_publish_public.
+DL_NAME_NEW="${PUBLIC_CA_DIR}/download-filename.new.$$"
+if halos_ca_download_filename "${HALOS_CA_ACTIVE_CRT}" > "${DL_NAME_NEW}" 2>/dev/null \
+   && mv "${DL_NAME_NEW}" "${PUBLIC_CA_DIR}/download-filename"; then
+    :
+else
+    rm -f "${DL_NAME_NEW}"
+    echo "WARNING: failed to write download-filename hint at ${PUBLIC_CA_DIR}/download-filename; the cert download falls back to the generic halos-ca.crt name." >&2
+fi
+
 # Explicit guard: `set -e` does NOT abort on command-substitution failure
 # in an assignment. Without it, a corrupt CA silently yields CA_FINGERPRINT=""
 # and feeds a malformed sentinel into downstream comparison — an infinite

--- a/assets/lib-ca.sh
+++ b/assets/lib-ca.sh
@@ -798,6 +798,26 @@ halos_ca_cn_hostname() {
     fi
 }
 
+# halos_ca_download_filename <crt_path>
+# Print the device-specific download filename for <crt_path>, derived from its
+# subject CN so the saved file is named after the cert's identity (the name the
+# trust store shows), not how the page was reached: "halos-ca-<hostname>.crt"
+# for a device-identifying CN, or the generic "halos-ca.crt" for a bare/legacy
+# or operator-custom CA (no embedded hostname). The hostname is sanitized to a
+# safe, length-capped filename component. The cert-manager writes this for the
+# ca-download sidecar, whose busybox image has no openssl to read the CN itself.
+halos_ca_download_filename() {
+    local crt="$1" host safe
+    host="$(halos_ca_cn_hostname "$crt")"
+    safe="$(printf '%s' "$host" | tr -d '\r\n' | sed 's/[^A-Za-z0-9._-]/-/g')"
+    safe="$(printf '%.64s' "$safe" | sed -e 's/^[._-]*//' -e 's/[._-]*$//')"
+    if [ -n "$safe" ]; then
+        printf 'halos-ca-%s.crt' "$safe"
+    else
+        printf 'halos-ca.crt'
+    fi
+}
+
 # halos_ca_adoption_init <adoption_file> <auto_ca_crt> <auto_created>
 # Ensure the adoption sentinel exists with a correct initial value, so the
 # ca-download sidecar's bind mount of this single file always finds a regular

--- a/docs/CERTS.md
+++ b/docs/CERTS.md
@@ -234,12 +234,17 @@ sidecar that serves the file returns it with:
 OS-level certificate install dialog instead of rendering the PEM as plain text.
 
 The saved filename is device-specific (`halos-ca-<host>.crt`) so several
-devices' certs are distinguishable in a Downloads folder. It is built **in the
-CGI** from the request `Host` header (port stripped, sanitized to
-`[A-Za-z0-9._-]`) — *not* client-side: a server `Content-Disposition` filename
-overrides an HTML `download` attribute, so a page-set name would never take
-effect. Accessed by raw IP, `<host>` is that IP. The URL path itself never
-changes.
+devices' certs are distinguishable in a Downloads folder. It is derived from the
+**active CA's subject CN** — i.e. the cert's own identity (the name the trust
+store shows), not how the page was reached — so a bare-CN / custom CA correctly
+downloads as the generic `halos-ca.crt`. Because busybox has no `openssl`, the
+cert-manager computes the name (`halos_ca_download_filename`) and writes it to
+`${PUBLIC_CA_DIR}/download-filename`; the CGI reads that for the
+`Content-Disposition`. This is server-side by necessity: a server
+`Content-Disposition` filename overrides an HTML `download` attribute, so a
+page-set name never takes effect. The landing page learns the name with a `HEAD`
+of the cert endpoint, so its instructions show the exact saved name. The URL
+path itself never changes.
 
 **The sidecar is `busybox httpd` + small CGI scripts** (not nginx): serving the
 `.crt` or `.mobileconfig` records first download by flipping the adoption

--- a/docs/solutions/2026-06-01-content-disposition-overrides-download-attribute.md
+++ b/docs/solutions/2026-06-01-content-disposition-overrides-download-attribute.md
@@ -30,13 +30,17 @@ sends a `Content-Disposition` filename.
 
 # Fix
 
-Set the device-specific filename **server-side**, in the cert CGI, from the
-request `Host` header (port stripped — bracket-aware for IPv6 — sanitized to
-`[A-Za-z0-9._-]`, length-capped, separators trimmed; the sanitization doubles as
-a header-injection guard). That is authoritative for browsers and `curl -OJ`
-alike. The page's JS keeps only display concerns: it fills the *instruction text*
-with the same computed name (mirroring the CGI's sanitization) so the steps name
-the file the user actually saved.
+Set the device-specific filename **server-side**, from the cert's **subject CN**
+— its actual identity (the name the trust store shows), not how the page was
+reached (a first cut used the request `Host` header, but that names the file
+after the access path, not the cert: a bare-CN or renamed-then-adopted cert
+would get a wrong/ambiguous name). Because the busybox sidecar has no `openssl`,
+the cert-manager computes the name and writes it to a file in the published dir;
+the CGI reads it for `Content-Disposition` (validating it to a safe shape). The
+landing page's JS keeps only display concerns and learns the name
+**authoritatively** via a `HEAD` of the cert endpoint — so the instruction text
+always shows the exact file the user saves, with no client-side re-derivation to
+drift out of sync.
 
 # How it slipped through — the verification lesson
 

--- a/tests/test-ca-download-cgi.sh
+++ b/tests/test-ca-download-cgi.sh
@@ -59,17 +59,19 @@ new_scratch() {
     { printf -- '-----BEGIN CERTIFICATE-----\n'; head -c "$bytes" /dev/zero | tr '\0' 'A'; printf '\n-----END CERTIFICATE-----\n'; } > "$d/halos-ca.crt"
     printf '<?xml version="1.0"?><plist>PROFILE</plist>\n' > "$d/halos-ca.mobileconfig"
     printf 'pending' > "$d/adoption"
+    # The cert-manager publishes the device download name here; default generic.
+    printf 'halos-ca.crt' > "$d/download-filename"
     printf '%s' "$d"
 }
 
 # Invoke a CGI with the scratch paths wired in. Usage:
-#   invoke <cgi> <scratch> <method> [http_host]
+#   invoke <cgi> <scratch> <method>
 invoke() {
     HALOS_CA_PUBLIC_CRT="$2/halos-ca.crt" \
     HALOS_CA_PUBLIC_PROFILE="$2/halos-ca.mobileconfig" \
     HALOS_ADOPTION_FILE="$2/adoption" \
+    HALOS_CA_DOWNLOAD_NAME="$2/download-filename" \
     REQUEST_METHOD="$3" \
-    HTTP_HOST="${4:-}" \
     sh "$1"
 }
 
@@ -89,70 +91,51 @@ test_cert_get_serves_and_adopts() {
     assert_eq "$(cat "$d/adoption")" "adopted" "completed GET must adopt" || return 1
 }
 
-test_cert_filename_from_host_is_device_specific() {
-    # The saved filename must be device-specific and come from the Host header
-    # (a server Content-Disposition filename overrides the page download attr).
-    local d; d=$(new_scratch cert_host)
-    local out; out=$(invoke "$CERT_CGI" "$d" GET halosdev.local)
-    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-halosdev.local.crt"' "device-specific filename from Host" || return 1
+test_cert_filename_from_name_file_is_device_specific() {
+    # The saved filename comes from the cert-manager-published name file (derived
+    # from the CA's CN), so it names the cert's identity, not how the page was
+    # reached. (The CN-to-name derivation itself is tested in test-lib-ca.sh.)
+    local d; d=$(new_scratch cert_namefile)
+    printf 'halos-ca-halosdev.local.crt' > "$d/download-filename"
+    local out; out=$(invoke "$CERT_CGI" "$d" GET)
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-halosdev.local.crt"' "device-specific filename from name file" || return 1
 }
 
-test_cert_filename_strips_host_port() {
-    local d; d=$(new_scratch cert_host_port)
-    local out; out=$(invoke "$CERT_CGI" "$d" GET "halosdev.local:8443")
-    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-halosdev.local.crt"' "port stripped from filename" || return 1
+test_cert_filename_default_when_name_file_absent() {
+    local d; d=$(new_scratch cert_no_namefile)
+    rm -f "$d/download-filename"
+    local out; out=$(invoke "$CERT_CGI" "$d" GET)
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca.crt"' "generic name when file absent" || return 1
 }
 
-test_cert_filename_falls_back_without_host() {
-    local d; d=$(new_scratch cert_no_host)
-    local out; out=$(invoke "$CERT_CGI" "$d" GET "")
-    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca.crt"' "bare filename when Host absent" || return 1
-}
-
-test_cert_filename_sanitizes_malicious_host() {
-    # A crafted Host with separators/quotes/spaces must collapse to a safe
-    # filename — no header injection, no stray quotes.
-    local d; d=$(new_scratch cert_evil_host)
-    local out; out=$(invoke "$CERT_CGI" "$d" GET 'a/b "c.local')
-    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-a-b--c.local.crt"' "host sanitized to safe filename" || return 1
-}
-
-test_cert_filename_no_crlf_header_injection() {
-    # A Host carrying a CRLF + a forged header must not inject one: CR/LF are
-    # stripped before sanitizing, so there is exactly one Content-Disposition
-    # line (with the forged text folded into the filename), and no Set-Cookie.
-    local d; d=$(new_scratch cert_crlf_host)
-    local out; out=$(invoke "$CERT_CGI" "$d" GET "$(printf 'evil\r\nSet-Cookie: pwned')")
-    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-evilSet-Cookie.crt"' "CRLF folded into filename, not injected" || return 1
+test_cert_filename_rejects_unsafe_name_file() {
+    # A name file with anything outside the expected halos-ca[-<safe>].crt shape
+    # (e.g. tampering, header-breaking chars) falls back to the generic name —
+    # no quote-breakout or header injection from the file contents.
+    local d; d=$(new_scratch cert_bad_namefile)
+    printf 'evil" \r\nSet-Cookie: x.crt' > "$d/download-filename"
+    local out; out=$(invoke "$CERT_CGI" "$d" GET)
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca.crt"' "unsafe name file rejected" || return 1
     local cd_lines; cd_lines=$(printf '%s\n' "$out" | grep -ci '^Content-Disposition:')
     assert_eq "$cd_lines" "1" "exactly one Content-Disposition line" || return 1
-    if printf '%s\n' "$out" | grep -qi '^Set-Cookie:'; then
-        echo "CRLF in Host injected a header"; return 1
-    fi
+    if printf '%s\n' "$out" | grep -qi '^Set-Cookie:'; then echo "name file injected a header"; return 1; fi
 }
 
-test_cert_filename_ipv6_bracketed() {
-    # A bracketed IPv6 Host keeps the address (port stripped); colons collapse
-    # to "-", so two IPv6 devices still get distinguishable filenames.
-    local d; d=$(new_scratch cert_ipv6)
-    local out; out=$(invoke "$CERT_CGI" "$d" GET "[2001:db8::1]:443")
-    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-2001-db8--1.crt"' "bracketed IPv6 filename" || return 1
-}
-
-test_cert_filename_length_capped() {
-    # An over-long Host must not produce a filename component over the 255-byte
-    # FS limit (which would truncate and could mask the .crt suffix).
-    local d; d=$(new_scratch cert_long_host)
-    local long; long=$(printf 'a%.0s' {1..300})
-    local out; out=$(invoke "$CERT_CGI" "$d" GET "${long}.local")
-    local expect; expect="attachment; filename=\"halos-ca-$(printf 'a%.0s' {1..64}).crt\""
-    assert_eq "$(cgi_hdr "$out" Content-Disposition)" "$expect" "host length capped at 64" || return 1
+test_cert_filename_rejects_empty_device_part() {
+    # A name with no device part after the prefix (halos-ca-.crt) — which the
+    # cert-manager never produces — must fall back to the generic name.
+    local d; d=$(new_scratch cert_empty_dev)
+    printf 'halos-ca-.crt' > "$d/download-filename"
+    local out; out=$(invoke "$CERT_CGI" "$d" GET)
+    assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca.crt"' "empty device part rejected" || return 1
 }
 
 test_cert_head_uses_device_filename() {
-    # HEAD shares emit_headers, so it must carry the same device-specific name.
-    local d; d=$(new_scratch cert_head_host)
-    local out; out=$(invoke "$CERT_CGI" "$d" HEAD halosdev.local)
+    # HEAD shares emit_headers (the landing page reads the name via HEAD), so it
+    # must carry the same device-specific name.
+    local d; d=$(new_scratch cert_head_name)
+    printf 'halos-ca-halosdev.local.crt' > "$d/download-filename"
+    local out; out=$(invoke "$CERT_CGI" "$d" HEAD)
     assert_eq "$(cgi_hdr "$out" Content-Disposition)" 'attachment; filename="halos-ca-halosdev.local.crt"' "HEAD device filename" || return 1
 }
 
@@ -231,13 +214,10 @@ test_gone_returns_410_with_canonical_hint() {
 }
 
 run_test test_cert_get_serves_and_adopts
-run_test test_cert_filename_from_host_is_device_specific
-run_test test_cert_filename_strips_host_port
-run_test test_cert_filename_falls_back_without_host
-run_test test_cert_filename_sanitizes_malicious_host
-run_test test_cert_filename_no_crlf_header_injection
-run_test test_cert_filename_ipv6_bracketed
-run_test test_cert_filename_length_capped
+run_test test_cert_filename_from_name_file_is_device_specific
+run_test test_cert_filename_default_when_name_file_absent
+run_test test_cert_filename_rejects_unsafe_name_file
+run_test test_cert_filename_rejects_empty_device_part
 run_test test_cert_head_uses_device_filename
 run_test test_cert_get_adopt_is_in_place
 run_test test_cert_head_serves_headers_without_adopting

--- a/tests/test-ca-download-endpoint.sh
+++ b/tests/test-ca-download-endpoint.sh
@@ -55,6 +55,9 @@ trap cleanup EXIT
 mkdir -p "$TMP/srv"
 printf -- '-----BEGIN CERTIFICATE-----\ndummy\n-----END CERTIFICATE-----\n' > "$TMP/srv/halos-ca.crt"
 printf '<?xml version="1.0"?><plist></plist>\n' > "$TMP/srv/halos-ca.mobileconfig"
+# Device download filename the cert-manager would publish (from the CA's CN);
+# the cert CGI reads it for Content-Disposition.
+printf 'halos-ca-testdev.example.crt' > "$TMP/srv/download-filename"
 # Single-file adoption sentinel. 0666 so the dropped uid (65534) can rewrite it
 # regardless of host ownership (Linux CI) — production chowns it to that uid.
 SENTINEL="$TMP/adoption"
@@ -108,10 +111,10 @@ check "GET /healthz leaves sentinel"       "pending" "$(cat "$SENTINEL")"
 reset_sentinel
 check "GET /ca/halos-ca.crt status"        "200" "$(code "$BASE/ca/halos-ca.crt")"
 check "GET /ca/halos-ca.crt content-type"  "application/x-x509-ca-cert" "$(hdr Content-Type "$BASE/ca/halos-ca.crt")"
-# Device-specific filename derived server-side from the Host header (curl sends
-# Host: 127.0.0.1:<port>; the CGI strips the port). A server filename overrides
-# the page's download attribute, which is why this must come from the server.
-check "GET /ca/halos-ca.crt disposition"   'attachment; filename="halos-ca-127.0.0.1.crt"' "$(hdr Content-Disposition "$BASE/ca/halos-ca.crt")"
+# Device-specific filename from the cert-manager-published name file (derived
+# from the CA's CN). A server filename overrides the page's download attribute,
+# which is why this must come from the server.
+check "GET /ca/halos-ca.crt disposition"   'attachment; filename="halos-ca-testdev.example.crt"' "$(hdr Content-Disposition "$BASE/ca/halos-ca.crt")"
 # Cross-boundary: the in-container CGI flipped the host-visible sentinel.
 check "completed cert GET adopts"          "adopted" "$(cat "$SENTINEL")"
 # Idempotent: a second download with the sentinel already adopted is a no-op.

--- a/tests/test-halos-manage-certs.sh
+++ b/tests/test-halos-manage-certs.sh
@@ -119,6 +119,7 @@ _auto_ca_crt() { printf '%s' "$1/data/halos-core-containers/certs/ca/ca.crt"; }
 _auto_ca_key() { printf '%s' "$1/data/halos-core-containers/certs/ca/ca.key"; }
 _public_ca() { printf '%s' "$1/data/halos-core-containers/certs/public/halos-ca.crt"; }
 _adoption_file() { printf '%s' "$1/data/halos-core-containers/certs/ca/adoption"; }
+_download_name_file() { printf '%s' "$1/data/halos-core-containers/certs/public/download-filename"; }
 _public_mobileconfig() { printf '%s' "$1/data/halos-core-containers/certs/public/halos-ca.mobileconfig"; }
 _cockpit_override() { printf '%s' "$1/cockpit-certs/99-halos.cert"; }
 _traefik_tls_config() { printf '%s' "$1/traefik-dynamic/tls-default.yml"; }
@@ -833,6 +834,23 @@ test_first_boot_auto_ca_cn_names_device() {
     assert_eq "$(_ca_cn "$(_auto_ca_crt "$d")")" "HaLOS Device CA (fixture.test)" "first-boot auto CA CN must name the device" || return 1
 }
 
+test_first_boot_publishes_device_download_filename() {
+    # The published download-filename hint (read by the ca-download CGI) is
+    # derived from the active CA's CN, so the saved file names the device.
+    local d; d=$(new_scratch dl_name)
+    run_script "$d" >/dev/null
+    assert_eq "$(cat "$(_download_name_file "$d")")" "halos-ca-fixture.test.crt" "download filename names the device" || return 1
+}
+
+test_legacy_bare_cn_download_filename_is_generic() {
+    # A frozen bare-CN CA has no device name, so the download filename stays
+    # generic — the file is named after the cert's identity.
+    local d; d=$(new_scratch dl_name_legacy)
+    _seed_auto_ca_with_cn "$d" "HaLOS Device CA" || { echo "seed failed"; return 1; }
+    run_script "$d" >/dev/null
+    assert_eq "$(cat "$(_download_name_file "$d")")" "halos-ca.crt" "bare-CN CA → generic download filename" || return 1
+}
+
 test_pending_rename_refreshes_cn() {
     # An unadopted device renamed before any download: the next run regenerates
     # the CA with the new CN (distinct from a plain hostname change, which
@@ -977,6 +995,8 @@ run_test test_legacy_bare_cn_ca_stamped_adopted
 run_test test_adoption_sentinel_preserved_on_rerun
 run_test test_publish_public_failure_logs_error
 run_test test_first_boot_auto_ca_cn_names_device
+run_test test_first_boot_publishes_device_download_filename
+run_test test_legacy_bare_cn_download_filename_is_generic
 run_test test_pending_rename_refreshes_cn
 run_test test_pending_rename_end_of_run_consistency
 run_test test_pending_no_rename_no_regen

--- a/tests/test-lib-ca.sh
+++ b/tests/test-lib-ca.sh
@@ -1668,6 +1668,27 @@ test_cn_hostname_empty_for_custom_cn() {
     assert_eq "$(halos_ca_cn_hostname "$d/ca.crt")" "" "non-device CN must yield empty hostname" || return 1
 }
 
+test_download_filename_device_cn() {
+    local d="$TMPDIR_ROOT/case_dlname_dev"
+    mkdir -p "$d"
+    _mk_ca_with_cn "$d/ca.crt" "HaLOS Device CA (halosdev.local)" || { echo "fixture failed"; return 1; }
+    assert_eq "$(halos_ca_download_filename "$d/ca.crt")" "halos-ca-halosdev.local.crt" "device CN yields device filename" || return 1
+}
+
+test_download_filename_bare_cn_is_generic() {
+    local d="$TMPDIR_ROOT/case_dlname_bare"
+    mkdir -p "$d"
+    _mk_ca_with_cn "$d/ca.crt" "HaLOS Device CA" || { echo "fixture failed"; return 1; }
+    assert_eq "$(halos_ca_download_filename "$d/ca.crt")" "halos-ca.crt" "bare CN yields generic filename" || return 1
+}
+
+test_download_filename_custom_cn_is_generic() {
+    local d="$TMPDIR_ROOT/case_dlname_custom"
+    mkdir -p "$d"
+    _mk_ca_with_cn "$d/ca.crt" "Acme Corp Root" || { echo "fixture failed"; return 1; }
+    assert_eq "$(halos_ca_download_filename "$d/ca.crt")" "halos-ca.crt" "custom CN yields generic filename" || return 1
+}
+
 test_select_active_threads_hostname_to_auto() {
     local d="$TMPDIR_ROOT/case_select_hostname"
     mkdir -p "$d/custom" "$d/auto"
@@ -1802,6 +1823,9 @@ run_test test_ensure_auto_bare_cn_without_hostname
 run_test test_ensure_auto_cn_round_trips
 run_test test_cn_hostname_empty_for_bare_cn
 run_test test_cn_hostname_empty_for_custom_cn
+run_test test_download_filename_device_cn
+run_test test_download_filename_bare_cn_is_generic
+run_test test_download_filename_custom_cn_is_generic
 run_test test_select_active_threads_hostname_to_auto
 run_test test_select_active_custom_cn_untouched_with_hostname
 

--- a/tests/test_landing_content.py
+++ b/tests/test_landing_content.py
@@ -108,21 +108,22 @@ def test_device_host_placeholder_present():
 
 def test_instruction_filenames_are_templated():
     # Every visible reference to the downloaded file is hooked so the JS can
-    # rewrite it to the device-specific name (matching the server-set save
-    # name). The static text stays halos-ca.crt as the no-JS fallback.
+    # rewrite it to the device-specific name. The static text stays halos-ca.crt
+    # as the no-JS fallback.
     assert "data-cert-filename" in HTML
     # The Linux cp command references the file twice — both must be hooked, so
     # a copy-pasted command names the file the user actually downloaded.
     assert HTML.count("data-cert-filename") >= 2
-    # The JS derives the same halos-ca-<host>.crt name the CGI does.
-    assert 'halos-ca-" + safe + ".crt' in HTML
 
 
-def test_device_name_falls_back_for_ip_access():
-    # The CA's CN embeds a DNS hostname, never an IP, so the on-page device
-    # name must fall back to "this device" when accessed by a raw IP.
+def test_filename_learned_authoritatively_from_server():
+    # The shown filename comes from the server's Content-Disposition (a HEAD of
+    # the cert endpoint), not a client-side guess — so it always equals the
+    # actual saved name. The fallback to "this device" stands when there is no
+    # device-identifying name.
+    assert 'method: "HEAD"' in HTML
+    assert "Content-Disposition" in HTML
     assert '"this device"' in HTML
-    assert "isIp" in HTML
 
 
 def test_trust_store_search_term_stable_for_old_certs():


### PR DESCRIPTION
Follow-up to #186. The download filename should reflect the **cert's identity (its CN)** — the name the trust store shows — not the `Host` the page was reached by.

## Why #186's Host-based name was wrong
`Host` is only a proxy for the cert, and they diverge exactly where it matters:
- **bare-CN / legacy CA** → Host gives `halos-ca-halosdev.local.crt`, but the cert is the generic `HaLOS Device CA`; it should be `halos-ca.crt`.
- **adopted-then-renamed device** → CN is frozen at the old name, Host has the new one; the file should match the cert.
- **accessed by IP / alias** → same cert, different Host → different filenames, making one cert look like several.

## Fix (CN-based)
- `lib-ca.sh` — `halos_ca_download_filename` derives `halos-ca-<host>.crt` from the CA's CN (generic `halos-ca.crt` for a bare-legacy or operator-custom CA).
- `halos-manage-certs` — publishes that name to `${PUBLIC_CA_DIR}/download-filename` (the busybox sidecar has no `openssl` to read the CN itself).
- cert CGI — reads the name file for `Content-Disposition`, validated to a safe `halos-ca[-<safe>].crt` shape with a generic fallback; the `Host` logic is gone.
- landing JS — learns the name **authoritatively** via a `HEAD` of the cert endpoint and fills both the filename references and the device-name context from it. No client-side re-derivation that could drift from the server.

## Verification
- Browser, served by busybox with a CN-derived name file: instructions show `halos-ca-halosdev.local.crt` and device name `halosdev.local`, equal to the server's `Content-Disposition` (`HEAD`).
- Docker endpoint test asserts the CGI emits the published name; lib-ca tests cover device/bare/custom CN → filename; manage-certs tests assert the published `download-filename`; CGI tests cover the name-file read, generic fallback, and rejection of a tampered/unsafe name.

All suites green: lib-ca 112, manage-certs 35, cgi 13, endpoint 23, hostnames 45, traefik 10, pytest 25. VERSION unchanged (cycle open).

Refs #176, #179