### PR TITLE
feat(certs): self-trust device CA in host trust store

### DIFF
--- a/assets/halos-manage-certs
+++ b/assets/halos-manage-certs
@@ -90,6 +90,11 @@ COCKPIT_WS_CERTS_DIR="${HALOS_COCKPIT_WS_CERTS_DIR:-/etc/cockpit/ws-certs.d}"
 COCKPIT_LEAF_OVERRIDE="${COCKPIT_WS_CERTS_DIR}/99-halos.cert"
 TRAEFIK_DYNAMIC_DIR="${HALOS_TRAEFIK_DYNAMIC_DIR:-/etc/halos/traefik-dynamic.d}"
 TRAEFIK_TLS_CONFIG="${TRAEFIK_DYNAMIC_DIR}/tls-default.yml"
+# Host CA trust store: the active CA is installed here so the device's own
+# desktop browser/CLI self-trust its HTTPS endpoints (#158). update_cmd is
+# overridable so tests can stub the bundle rebuild.
+SYSTEM_TRUST_DIR="${HALOS_SYSTEM_TRUST_DIR:-/usr/local/share/ca-certificates}"
+UPDATE_CA_CMD="${HALOS_UPDATE_CA_CMD:-update-ca-certificates}"
 
 mkdir -p "${CERTS_DIR}"
 
@@ -154,6 +159,19 @@ fi
 # the served CA is missing or stale.
 if ! halos_ca_publish_public "${HALOS_CA_ACTIVE_CRT}" "${PUBLIC_CA_DIR}"; then
     echo "ERROR: failed to publish CA copy at ${PUBLIC_CA_DIR}/halos-ca.crt; the /ca/halos-ca.crt download endpoint may serve stale or no CA until the next successful run." >&2
+fi
+
+# Install the active CA into the host system trust store so the device's own
+# desktop browser and CLI tools validate its HTTPS endpoints without operator
+# action (#158). The helper skips the costly update-ca-certificates rebuild
+# when the store already holds this CA, so the renewal timer doesn't churn the
+# bundle; only a CA rotation re-triggers it.
+#
+# Auxiliary: failure does NOT abort. A device that can't self-trust is a
+# quality regression, not a stack-blocking fault — the container leaf and its
+# CA are already in place by this point.
+if ! halos_ca_publish_system_trust "${HALOS_CA_ACTIVE_CRT}" "${SYSTEM_TRUST_DIR}" "${UPDATE_CA_CMD}"; then
+    echo "WARNING: failed to install the active CA into the host trust store at ${SYSTEM_TRUST_DIR}; the device's own browser/CLI may show cert warnings until the next successful run." >&2
 fi
 
 # Generate the Apple Configuration Profile (.mobileconfig) carrying the active

--- a/assets/halos-manage-certs
+++ b/assets/halos-manage-certs
@@ -91,8 +91,8 @@ COCKPIT_LEAF_OVERRIDE="${COCKPIT_WS_CERTS_DIR}/99-halos.cert"
 TRAEFIK_DYNAMIC_DIR="${HALOS_TRAEFIK_DYNAMIC_DIR:-/etc/halos/traefik-dynamic.d}"
 TRAEFIK_TLS_CONFIG="${TRAEFIK_DYNAMIC_DIR}/tls-default.yml"
 # Host CA trust store: the active CA is installed here so the device's own
-# desktop browser/CLI self-trust its HTTPS endpoints (#158). update_cmd is
-# overridable so tests can stub the bundle rebuild.
+# desktop browser/CLI self-trust its HTTPS endpoints (#158). HALOS_UPDATE_CA_CMD
+# is overridable so tests can stub the bundle rebuild.
 SYSTEM_TRUST_DIR="${HALOS_SYSTEM_TRUST_DIR:-/usr/local/share/ca-certificates}"
 UPDATE_CA_CMD="${HALOS_UPDATE_CA_CMD:-update-ca-certificates}"
 

--- a/assets/lib-ca.sh
+++ b/assets/lib-ca.sh
@@ -786,8 +786,12 @@ halos_ca_publish_public() {
 # rebuilding the system bundle each time would be pure churn. Only a CA
 # rotation (content change) re-triggers the rebuild.
 #
-# Failure semantics: on any failure leaves the pre-existing trust copy (if any)
-# untouched, removes the .new sibling, returns non-zero.
+# Failure semantics: a stage/cp/parse/mv failure leaves the pre-existing trust
+# copy (if any) untouched and removes the .new sibling. An update_cmd failure
+# happens after the new cert is installed, so the helper removes that file too —
+# leaving the next run a clean mismatch to retry, rather than a file that would
+# make the cmp short-circuit skip the rebuild forever. All failures return
+# non-zero.
 #
 # Return codes:
 #   0 — success (installed + rebuilt, or already current)
@@ -846,8 +850,15 @@ halos_ca_publish_system_trust() {
         return 1
     fi
 
-    if ! "$update_cmd" >/dev/null 2>&1; then
-        echo "halos_ca_publish_system_trust: $update_cmd failed; trust file installed but the system bundle was not rebuilt" >&2
+    # stdout is the progress ticker (noise); let stderr through so the journal
+    # carries the actual diagnostic when the rebuild fails.
+    if ! "$update_cmd" >/dev/null; then
+        # The new cert is already installed (mv above), but the bundle wasn't
+        # rebuilt. Remove the staged file so the next run sees a mismatch and
+        # retries — otherwise the cmp short-circuit would skip the rebuild
+        # forever and the device would never trust its own CA.
+        rm -f "$trust_file"
+        echo "halos_ca_publish_system_trust: $update_cmd failed; removed the trust file so the next run retries the rebuild" >&2
         return 1
     fi
 }

--- a/assets/lib-ca.sh
+++ b/assets/lib-ca.sh
@@ -690,6 +690,52 @@ halos_cockpit_install_leaf() {
     fi
 }
 
+# _halos_ca_atomic_install <src_crt> <dest_file>
+# Stage <src_crt> beside <dest_file>, verify it parses as X.509, chmod 0644,
+# then atomically mv it into place. The parent dir of <dest_file> must already
+# exist — callers own directory creation and mode. Shared by the public-CA and
+# system-trust publishers.
+#
+# Staging uses a PID-suffixed sibling so concurrent callers don't collide; the
+# rm before cp keeps cp from following a pre-existing symlink at the stage path.
+# The X.509 parse check catches truncation, EIO mid-cp, and a src that drifted
+# to a non-cert. Refuses to install over a directory (plain mv would move INTO
+# it).
+#
+# Failure semantics: on any failure removes the .new sibling, leaves any
+# pre-existing <dest_file> untouched, prints a diagnostic, returns 1.
+_halos_ca_atomic_install() {
+    local src_crt="$1" dest_file="$2"
+    local dest_new="${dest_file}.new.$$"
+    rm -f "$dest_new"
+
+    if ! cp "$src_crt" "$dest_new"; then
+        rm -f "$dest_new"
+        echo "_halos_ca_atomic_install: failed to cp $src_crt to $dest_new" >&2
+        return 1
+    fi
+    if ! openssl x509 -in "$dest_new" -noout 2>/dev/null; then
+        rm -f "$dest_new"
+        echo "_halos_ca_atomic_install: copied file at $dest_new does not parse as an X.509 certificate" >&2
+        return 1
+    fi
+    if ! chmod 0644 "$dest_new"; then
+        rm -f "$dest_new"
+        echo "_halos_ca_atomic_install: chmod 0644 failed on $dest_new" >&2
+        return 1
+    fi
+    if [ -d "$dest_file" ]; then
+        rm -f "$dest_new"
+        echo "_halos_ca_atomic_install: refusing to install over directory at $dest_file" >&2
+        return 1
+    fi
+    if ! mv "$dest_new" "$dest_file"; then
+        rm -f "$dest_new"
+        echo "_halos_ca_atomic_install: failed to mv $dest_new to $dest_file; previous copy (if any) is preserved" >&2
+        return 1
+    fi
+}
+
 # halos_ca_publish_public <src_crt> <public_dir>
 # Atomically refresh a world-readable copy of <src_crt> at
 # <public_dir>/halos-ca.crt, mode 0644. Used by prestart to publish the active
@@ -732,53 +778,14 @@ halos_ca_publish_public() {
     # who narrowed it (e.g., debugging) doesn't break the bind-mount.
     chmod 0755 "$public_dir" 2>/dev/null || true
 
-    local public_file="${public_dir}/halos-ca.crt"
-    # PID-suffixed stage filename so concurrent prestart invocations don't
-    # collide on the same staging path. The mv into public_file is still
-    # atomic per caller.
-    local public_new="${public_file}.new.$$"
-    # rm before cp so `>` inside cp doesn't follow a pre-existing symlink at
-    # the stage path. (cp itself doesn't follow target symlinks by default
-    # for overwrite, but the per-pid name minimizes the surface anyway.)
-    rm -f "$public_new"
-
-    if ! cp "$src_crt" "$public_new"; then
-        rm -f "$public_new"
-        echo "halos_ca_publish_public: failed to cp $src_crt to $public_new" >&2
-        return 1
-    fi
-    # Verify the copy parses as an X.509 cert. Catches truncation, EIO mid-
-    # cp, and the case where src_crt drifted to something that isn't a cert.
-    if ! openssl x509 -in "$public_new" -noout 2>/dev/null; then
-        rm -f "$public_new"
-        echo "halos_ca_publish_public: copied file at $public_new does not parse as an X.509 certificate" >&2
-        return 1
-    fi
-    if ! chmod 0644 "$public_new"; then
-        rm -f "$public_new"
-        echo "halos_ca_publish_public: chmod 0644 failed on $public_new" >&2
-        return 1
-    fi
-    # Refuse to install over a pre-existing directory at public_file (plain
-    # mv would silently move INTO the directory).
-    if [ -d "$public_file" ]; then
-        rm -f "$public_new"
-        echo "halos_ca_publish_public: refusing to install over directory at $public_file" >&2
-        return 1
-    fi
-    if ! mv "$public_new" "$public_file"; then
-        rm -f "$public_new"
-        echo "halos_ca_publish_public: failed to mv $public_new to $public_file; previous copy (if any) is preserved" >&2
-        return 1
-    fi
+    _halos_ca_atomic_install "$src_crt" "${public_dir}/halos-ca.crt"
 }
 
 # halos_ca_publish_system_trust <src_crt> <trust_dir> [update_cmd]
 # Install <src_crt> into the host CA trust store at <trust_dir>/halos-ca.crt
 # (mode 0644) and run <update_cmd> (default update-ca-certificates) so the
 # device's own desktop browser and CLI tools validate its HTTPS endpoints with
-# no operator action. The atomic stage+mv and X.509-parse check mirror
-# halos_ca_publish_public.
+# no operator action.
 #
 # Idempotent by design: when the installed copy already matches <src_crt>
 # byte-for-byte, the file is left untouched and <update_cmd> is NOT run.
@@ -821,32 +828,7 @@ halos_ca_publish_system_trust() {
         return 1
     fi
 
-    local trust_new="${trust_file}.new.$$"
-    rm -f "$trust_new"
-
-    if ! cp "$src_crt" "$trust_new"; then
-        rm -f "$trust_new"
-        echo "halos_ca_publish_system_trust: failed to cp $src_crt to $trust_new" >&2
-        return 1
-    fi
-    if ! openssl x509 -in "$trust_new" -noout 2>/dev/null; then
-        rm -f "$trust_new"
-        echo "halos_ca_publish_system_trust: copied file at $trust_new does not parse as an X.509 certificate" >&2
-        return 1
-    fi
-    if ! chmod 0644 "$trust_new"; then
-        rm -f "$trust_new"
-        echo "halos_ca_publish_system_trust: chmod 0644 failed on $trust_new" >&2
-        return 1
-    fi
-    if [ -d "$trust_file" ]; then
-        rm -f "$trust_new"
-        echo "halos_ca_publish_system_trust: refusing to install over directory at $trust_file" >&2
-        return 1
-    fi
-    if ! mv "$trust_new" "$trust_file"; then
-        rm -f "$trust_new"
-        echo "halos_ca_publish_system_trust: failed to mv $trust_new to $trust_file; previous copy (if any) is preserved" >&2
+    if ! _halos_ca_atomic_install "$src_crt" "$trust_file"; then
         return 1
     fi
 

--- a/assets/lib-ca.sh
+++ b/assets/lib-ca.sh
@@ -20,6 +20,8 @@
 #                                              copy active CA into a public-bindmount target
 #   - halos_ca_publish_mobileconfig <src_crt> <public_dir> <display_host>
 #                                              generate an Apple .mobileconfig carrying the CA
+#   - halos_ca_publish_system_trust <src_crt> <trust_dir> [update_cmd]
+#                                              install active CA into host trust store + rebuild
 #
 # Generated certs carry the extensions browsers + OS trust stores require:
 #   CA   — basicConstraints CA:TRUE (so importing as trust anchor actually works),
@@ -767,6 +769,85 @@ halos_ca_publish_public() {
     if ! mv "$public_new" "$public_file"; then
         rm -f "$public_new"
         echo "halos_ca_publish_public: failed to mv $public_new to $public_file; previous copy (if any) is preserved" >&2
+        return 1
+    fi
+}
+
+# halos_ca_publish_system_trust <src_crt> <trust_dir> [update_cmd]
+# Install <src_crt> into the host CA trust store at <trust_dir>/halos-ca.crt
+# (mode 0644) and run <update_cmd> (default update-ca-certificates) so the
+# device's own desktop browser and CLI tools validate its HTTPS endpoints with
+# no operator action. The atomic stage+mv and X.509-parse check mirror
+# halos_ca_publish_public.
+#
+# Idempotent by design: when the installed copy already matches <src_crt>
+# byte-for-byte, the file is left untouched and <update_cmd> is NOT run.
+# halos-manage-certs re-fires on every boot and on the 24h renewal timer;
+# rebuilding the system bundle each time would be pure churn. Only a CA
+# rotation (content change) re-triggers the rebuild.
+#
+# Failure semantics: on any failure leaves the pre-existing trust copy (if any)
+# untouched, removes the .new sibling, returns non-zero.
+#
+# Return codes:
+#   0 — success (installed + rebuilt, or already current)
+#   1 — runtime failure (missing source, write/chmod/mv error, parse fail,
+#       update_cmd failure)
+#   2 — caller bug (missing args)
+halos_ca_publish_system_trust() {
+    local src_crt="$1" trust_dir="$2" update_cmd="${3:-update-ca-certificates}"
+    if [ -z "$src_crt" ] || [ -z "$trust_dir" ]; then
+        echo "halos_ca_publish_system_trust: <src_crt> <trust_dir> both required" >&2
+        return 2
+    fi
+    if [ ! -f "$src_crt" ]; then
+        echo "halos_ca_publish_system_trust: source cert missing: $src_crt" >&2
+        return 1
+    fi
+
+    local trust_file="${trust_dir}/halos-ca.crt"
+    # Already current: skip the costly bundle rebuild. This is the common path
+    # on every non-rotation run.
+    if [ -f "$trust_file" ] && cmp -s "$src_crt" "$trust_file"; then
+        return 0
+    fi
+
+    if ! mkdir -p "$trust_dir"; then
+        echo "halos_ca_publish_system_trust: failed to mkdir $trust_dir" >&2
+        return 1
+    fi
+
+    local trust_new="${trust_file}.new.$$"
+    rm -f "$trust_new"
+
+    if ! cp "$src_crt" "$trust_new"; then
+        rm -f "$trust_new"
+        echo "halos_ca_publish_system_trust: failed to cp $src_crt to $trust_new" >&2
+        return 1
+    fi
+    if ! openssl x509 -in "$trust_new" -noout 2>/dev/null; then
+        rm -f "$trust_new"
+        echo "halos_ca_publish_system_trust: copied file at $trust_new does not parse as an X.509 certificate" >&2
+        return 1
+    fi
+    if ! chmod 0644 "$trust_new"; then
+        rm -f "$trust_new"
+        echo "halos_ca_publish_system_trust: chmod 0644 failed on $trust_new" >&2
+        return 1
+    fi
+    if [ -d "$trust_file" ]; then
+        rm -f "$trust_new"
+        echo "halos_ca_publish_system_trust: refusing to install over directory at $trust_file" >&2
+        return 1
+    fi
+    if ! mv "$trust_new" "$trust_file"; then
+        rm -f "$trust_new"
+        echo "halos_ca_publish_system_trust: failed to mv $trust_new to $trust_file; previous copy (if any) is preserved" >&2
+        return 1
+    fi
+
+    if ! "$update_cmd" >/dev/null 2>&1; then
+        echo "halos_ca_publish_system_trust: $update_cmd failed; trust file installed but the system bundle was not rebuilt" >&2
         return 1
     fi
 }

--- a/docs/CERTS.md
+++ b/docs/CERTS.md
@@ -212,6 +212,21 @@ The refresh only fires when the CA's embedded name differs from the current
 hostname: resetting to `pending` on a CA that already names the current host is
 a no-op (no regeneration, no re-trust cost).
 
+## Host self-trust
+
+So a device that runs its own desktop reaches its dashboard without cert
+warnings, `halos-manage-certs` also installs the active CA into the host trust
+store at `/usr/local/share/ca-certificates/halos-ca.crt` and runs
+`update-ca-certificates` (helper `halos_ca_publish_system_trust` in
+`lib-ca.sh`). This makes the device's own browser and CLI tools validate its
+HTTPS endpoints with no operator action.
+
+The bundle rebuild is skipped when the store already holds the active CA, so
+the 24 h renewal timer doesn't churn it — only a CA rotation re-triggers
+`update-ca-certificates`. Aux-failure semantics: a failure logs `WARNING` and
+never blocks cert management. The step runs on every variant; on a headless
+device it is harmless (the device simply trusts its own CA for local tooling).
+
 ## CA download endpoint
 
 The active CA is published at:

--- a/tests/test-halos-manage-certs.sh
+++ b/tests/test-halos-manage-certs.sh
@@ -1026,6 +1026,23 @@ test_ca_rotation_reinstalls_system_trust() {
     fi
 }
 
+test_system_trust_update_failure_is_nonfatal() {
+    # An update-ca-certificates failure is auxiliary: the script must still exit
+    # 0, still produce the leaf, log a WARNING, and remove the trust file so the
+    # next run retries (self-heal — see the helper's failed-update path).
+    local d; d=$(new_scratch systrust_update_fail)
+    printf '#!/bin/sh\nexit 1\n' > "$d/fake-update-ca"
+    chmod +x "$d/fake-update-ca"
+    local out rc
+    out=$(run_script "$d" 2>&1); rc=$?
+    assert_eq "$rc" "0" "aux update-ca failure must not abort the script" || return 1
+    assert_file "$(_cert_file "$d")" "leaf must still be produced when system-trust update fails" || return 1
+    assert_no_file "$(_system_trust_ca "$d")" "trust file must be removed on update failure (self-heal)" || return 1
+    if ! printf '%s' "$out" | grep -q "WARNING.*trust store"; then
+        echo "expected WARNING about the host trust store; got: $out"; return 1
+    fi
+}
+
 # ---------------------------------------------------------------------------
 
 run_test test_first_boot_bootstrap_creates_all_artifacts
@@ -1066,6 +1083,7 @@ run_test test_custom_ca_cn_untouched
 run_test test_first_boot_installs_ca_in_system_trust
 run_test test_idempotent_rerun_skips_system_trust_update
 run_test test_ca_rotation_reinstalls_system_trust
+run_test test_system_trust_update_failure_is_nonfatal
 
 echo
 echo "Passed: $PASSES, Failed: $FAILS"

--- a/tests/test-halos-manage-certs.sh
+++ b/tests/test-halos-manage-certs.sh
@@ -68,8 +68,15 @@ run_test() {
 # COCKPIT_WS_CERTS_DIR is created so the cockpit-override branch runs.
 new_scratch() {
     local d="$TMPDIR_ROOT/$1"
-    mkdir -p "$d/data" "$d/etc" "$d/custom-ca" "$d/cockpit-certs" "$d/traefik-dynamic"
+    mkdir -p "$d/data" "$d/etc" "$d/custom-ca" "$d/cockpit-certs" "$d/traefik-dynamic" "$d/system-trust"
     printf '%s\n' "fixture.test" > "$d/hostnames.conf"
+    # Stub update-ca-certificates: record each invocation so tests can assert
+    # the host trust store was (or was not) rebuilt.
+    cat > "$d/fake-update-ca" <<EOF
+#!/bin/sh
+echo ran >> "$d/update-ca-ran"
+EOF
+    chmod +x "$d/fake-update-ca"
     printf '%s' "$d"
 }
 
@@ -106,6 +113,8 @@ run_script() {
     HALOS_COCKPIT_WS_CERTS_DIR="$d/cockpit-certs" \
     HALOS_TRAEFIK_DYNAMIC_DIR="$d/traefik-dynamic" \
     HALOS_HOSTNAMES_FILE="$d/hostnames.conf" \
+    HALOS_SYSTEM_TRUST_DIR="$d/system-trust" \
+    HALOS_UPDATE_CA_CMD="$d/fake-update-ca" \
     PACKAGE_NAME="halos-core-containers" \
     CONTAINER_DATA_ROOT="$d/data" \
     bash "$SCRIPT"
@@ -123,6 +132,8 @@ _download_name_file() { printf '%s' "$1/data/halos-core-containers/certs/public/
 _public_mobileconfig() { printf '%s' "$1/data/halos-core-containers/certs/public/halos-ca.mobileconfig"; }
 _cockpit_override() { printf '%s' "$1/cockpit-certs/99-halos.cert"; }
 _traefik_tls_config() { printf '%s' "$1/traefik-dynamic/tls-default.yml"; }
+_system_trust_ca() { printf '%s' "$1/system-trust/halos-ca.crt"; }
+_update_ca_marker() { printf '%s' "$1/update-ca-ran"; }
 
 # ---------------------------------------------------------------------------
 
@@ -967,6 +978,54 @@ test_custom_ca_cn_untouched() {
     assert_no_file "$(_auto_ca_crt "$d")" "auto CA must not be generated in custom mode" || return 1
 }
 
+test_first_boot_installs_ca_in_system_trust() {
+    # #158: the device self-trusts its own CA. First boot must install the
+    # active CA into the host trust store and rebuild the bundle.
+    local d; d=$(new_scratch systrust_first_boot)
+    run_script "$d" >/dev/null
+    assert_file "$(_system_trust_ca "$d")" "host trust-store CA copy" || return 1
+    assert_file "$(_update_ca_marker "$d")" "update-ca-certificates must run on first boot" || return 1
+    if ! cmp -s "$(_public_ca "$d")" "$(_system_trust_ca "$d")"; then
+        echo "host trust-store CA must match the active (published) CA"; return 1
+    fi
+}
+
+test_idempotent_rerun_skips_system_trust_update() {
+    # The renewal timer re-fires on every cycle; an unchanged CA must NOT
+    # rebuild the host bundle.
+    local d; d=$(new_scratch systrust_rerun)
+    run_script "$d" >/dev/null
+    assert_file "$(_update_ca_marker "$d")" "precondition: first boot rebuilt the bundle" || return 1
+    rm -f "$(_update_ca_marker "$d")"
+    sleep 1
+    run_script "$d" >/dev/null
+    assert_no_file "$(_update_ca_marker "$d")" "update must NOT re-run when the CA is unchanged" || return 1
+}
+
+test_ca_rotation_reinstalls_system_trust() {
+    # A rotated CA (expired → regenerated) must re-install into the trust store
+    # and rebuild the bundle.
+    local d; d=$(new_scratch systrust_rotation)
+    run_script "$d" >/dev/null
+    rm -f "$(_update_ca_marker "$d")"
+    local nb na
+    nb=$(date -u -d "@$(( $(date -u +%s) - 30 * 86400 ))" +%Y%m%d%H%M%SZ 2>/dev/null \
+        || date -u -r "$(( $(date -u +%s) - 30 * 86400 ))" +%Y%m%d%H%M%SZ)
+    na=$(date -u -d "@$(( $(date -u +%s) - 86400 ))" +%Y%m%d%H%M%SZ 2>/dev/null \
+        || date -u -r "$(( $(date -u +%s) - 86400 ))" +%Y%m%d%H%M%SZ)
+    openssl req -x509 -nodes -key "$(_auto_ca_key "$d")" -out "$(_auto_ca_crt "$d")" \
+        -not_before "$nb" -not_after "$na" -subj "/CN=Expired Auto CA" \
+        -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1 \
+        || { echo "expired-CA fixture failed"; return 1; }
+    sleep 1
+    run_script "$d" >/dev/null
+    assert_file "$(_update_ca_marker "$d")" "update must re-run on CA rotation" || return 1
+    if ! cmp -s "$(_public_ca "$d")" "$(_system_trust_ca "$d")"; then
+        echo "host trust-store CA must track the rotated CA"; return 1
+    fi
+}
+
 # ---------------------------------------------------------------------------
 
 run_test test_first_boot_bootstrap_creates_all_artifacts
@@ -1004,6 +1063,9 @@ run_test test_adopted_rename_freezes_cn
 run_test test_legacy_bare_cn_frozen_on_rename
 run_test test_expiry_regen_uses_current_hostname_when_adopted
 run_test test_custom_ca_cn_untouched
+run_test test_first_boot_installs_ca_in_system_trust
+run_test test_idempotent_rerun_skips_system_trust_update
+run_test test_ca_rotation_reinstalls_system_trust
 
 echo
 echo "Passed: $PASSES, Failed: $FAILS"

--- a/tests/test-lib-ca.sh
+++ b/tests/test-lib-ca.sh
@@ -1187,6 +1187,135 @@ test_publish_public_no_new_debris_on_success() {
     ! ls "$pub"/halos-ca.crt.new.* >/dev/null 2>&1 || { echo ".new.<pid> sibling should not remain after success"; return 1; }
 }
 
+# A stub update-ca-certificates that records each invocation by appending a
+# line to <dir>/update-ran. Echoes the script path.
+_make_update_stub() {
+    local dir="$1"
+    local stub="$dir/fake-update-ca"
+    cat > "$stub" <<EOF
+#!/bin/sh
+echo ran >> "$dir/update-ran"
+EOF
+    chmod +x "$stub"
+    printf '%s' "$stub"
+}
+
+test_publish_system_trust_happy_path() {
+    local d="$TMPDIR_ROOT/case_systrust_happy"
+    local trust="$d/trust"
+    mkdir -p "$d"
+    halos_ca_ensure_auto "$d" || return 1
+    local upd; upd=$(_make_update_stub "$d")
+    halos_ca_publish_system_trust "$d/ca.crt" "$trust" "$upd" \
+        || { echo "publish_system_trust returned non-zero"; return 1; }
+    [ -f "$trust/halos-ca.crt" ] || { echo "trust file not created"; return 1; }
+    local mode; mode=$(_stat_mode "$trust/halos-ca.crt")
+    assert_eq "$mode" "644" "trust file mode must be 0644" || return 1
+    if ! cmp -s "$d/ca.crt" "$trust/halos-ca.crt"; then
+        echo "trust file content does not match source"; return 1
+    fi
+    [ -f "$d/update-ran" ] || { echo "update-ca-certificates stub was not run"; return 1; }
+}
+
+test_publish_system_trust_skips_update_when_current() {
+    # The renewal timer re-fires this path on every run; an unchanged CA must
+    # NOT rebuild the bundle.
+    local d="$TMPDIR_ROOT/case_systrust_skip"
+    local trust="$d/trust"
+    mkdir -p "$d"
+    halos_ca_ensure_auto "$d" || return 1
+    local upd; upd=$(_make_update_stub "$d")
+    halos_ca_publish_system_trust "$d/ca.crt" "$trust" "$upd" || return 1
+    rm -f "$d/update-ran"
+    halos_ca_publish_system_trust "$d/ca.crt" "$trust" "$upd" || return 1
+    [ ! -f "$d/update-ran" ] || { echo "update must NOT re-run when CA is unchanged"; return 1; }
+}
+
+test_publish_system_trust_runs_update_on_rotation() {
+    # A rotated (content-changed) CA must re-install and rebuild the bundle.
+    local da="$TMPDIR_ROOT/case_systrust_rot_a"
+    local db="$TMPDIR_ROOT/case_systrust_rot_b"
+    local trust="$TMPDIR_ROOT/case_systrust_rot_trust"
+    mkdir -p "$da" "$db"
+    halos_ca_ensure_auto "$da" || return 1
+    halos_ca_ensure_auto "$db" || return 1
+    local upd; upd=$(_make_update_stub "$TMPDIR_ROOT")
+    halos_ca_publish_system_trust "$da/ca.crt" "$trust" "$upd" || return 1
+    rm -f "$TMPDIR_ROOT/update-ran"
+    halos_ca_publish_system_trust "$db/ca.crt" "$trust" "$upd" || return 1
+    [ -f "$TMPDIR_ROOT/update-ran" ] || { echo "update must re-run on CA rotation"; return 1; }
+    if ! cmp -s "$db/ca.crt" "$trust/halos-ca.crt"; then
+        echo "rotated trust file does not match new source"; return 1
+    fi
+    rm -f "$TMPDIR_ROOT/update-ran"
+}
+
+test_publish_system_trust_missing_args_errors() {
+    halos_ca_publish_system_trust "" "" >/dev/null 2>&1
+    local rc=$?
+    assert_eq "$rc" "2" "missing args must exit 2 (caller bug)" || return 1
+}
+
+test_publish_system_trust_missing_source_errors() {
+    local d="$TMPDIR_ROOT/case_systrust_missing_src"
+    mkdir -p "$d"
+    halos_ca_publish_system_trust "$d/nope.crt" "$d/trust" >/dev/null 2>&1
+    local rc=$?
+    assert_eq "$rc" "1" "missing source must exit 1 (runtime failure)" || return 1
+    [ ! -f "$d/trust/halos-ca.crt" ] || { echo "no output should be written"; return 1; }
+}
+
+test_publish_system_trust_rejects_non_cert_source() {
+    local d="$TMPDIR_ROOT/case_systrust_bad_src"
+    local trust="$d/trust"
+    mkdir -p "$d"
+    printf 'not a certificate\n' > "$d/bad.crt"
+    local upd; upd=$(_make_update_stub "$d")
+    halos_ca_publish_system_trust "$d/bad.crt" "$trust" "$upd" >/dev/null 2>&1
+    local rc=$?
+    assert_eq "$rc" "1" "non-cert source must exit 1" || return 1
+    [ ! -f "$trust/halos-ca.crt" ] || { echo "no output should be written"; return 1; }
+    [ ! -f "$d/update-ran" ] || { echo "update must NOT run when source is rejected"; return 1; }
+    ! ls "$trust"/halos-ca.crt.new.* >/dev/null 2>&1 || { echo "no .new debris should remain"; return 1; }
+}
+
+test_publish_system_trust_preserves_existing_on_failure() {
+    local d="$TMPDIR_ROOT/case_systrust_preserve"
+    local trust="$d/trust"
+    mkdir -p "$d"
+    halos_ca_ensure_auto "$d" || return 1
+    local upd; upd=$(_make_update_stub "$d")
+    halos_ca_publish_system_trust "$d/ca.crt" "$trust" "$upd" || return 1
+    local good_hash; good_hash=$(openssl dgst -sha256 "$trust/halos-ca.crt" | awk '{print $NF}')
+    printf 'not a certificate\n' > "$d/bad.crt"
+    halos_ca_publish_system_trust "$d/bad.crt" "$trust" "$upd" >/dev/null 2>&1
+    local after_hash; after_hash=$(openssl dgst -sha256 "$trust/halos-ca.crt" | awk '{print $NF}')
+    assert_eq "$after_hash" "$good_hash" "previous trust file must be preserved on failure" || return 1
+}
+
+test_publish_system_trust_refuses_directory_at_output() {
+    local d="$TMPDIR_ROOT/case_systrust_dir_at_out"
+    local trust="$d/trust"
+    mkdir -p "$d" "$trust/halos-ca.crt"
+    halos_ca_ensure_auto "$d" || return 1
+    local upd; upd=$(_make_update_stub "$d")
+    halos_ca_publish_system_trust "$d/ca.crt" "$trust" "$upd" >/dev/null 2>&1
+    local rc=$?
+    assert_eq "$rc" "1" "directory at output must exit 1" || return 1
+    [ -d "$trust/halos-ca.crt" ] || { echo "directory must be preserved"; return 1; }
+    ! ls "$trust"/halos-ca.crt.new.* >/dev/null 2>&1 || { echo "no .new debris should remain"; return 1; }
+}
+
+test_publish_system_trust_no_new_debris_on_success() {
+    local d="$TMPDIR_ROOT/case_systrust_no_debris"
+    local trust="$d/trust"
+    mkdir -p "$d"
+    halos_ca_ensure_auto "$d" || return 1
+    local upd; upd=$(_make_update_stub "$d")
+    halos_ca_publish_system_trust "$d/ca.crt" "$trust" "$upd" || return 1
+    ! ls "$trust"/halos-ca.crt.new.* >/dev/null 2>&1 || { echo ".new.<pid> sibling should not remain after success"; return 1; }
+}
+
 # Decode the base64 <data> payload from a .mobileconfig into a DER file.
 # Pulls the single-line base64 between the <data> tags (our generator emits it
 # flattened), strips whitespace, and base64-decodes. Echoes the DER path.
@@ -1785,6 +1914,15 @@ run_test test_publish_public_rejects_non_cert_source
 run_test test_publish_public_preserves_existing_on_failure
 run_test test_publish_public_refuses_directory_at_output
 run_test test_publish_public_no_new_debris_on_success
+run_test test_publish_system_trust_happy_path
+run_test test_publish_system_trust_skips_update_when_current
+run_test test_publish_system_trust_runs_update_on_rotation
+run_test test_publish_system_trust_missing_args_errors
+run_test test_publish_system_trust_missing_source_errors
+run_test test_publish_system_trust_rejects_non_cert_source
+run_test test_publish_system_trust_preserves_existing_on_failure
+run_test test_publish_system_trust_refuses_directory_at_output
+run_test test_publish_system_trust_no_new_debris_on_success
 run_test test_publish_mobileconfig_happy_path
 run_test test_publish_mobileconfig_der_round_trips
 run_test test_publish_mobileconfig_embeds_display_host

--- a/tests/test-lib-ca.sh
+++ b/tests/test-lib-ca.sh
@@ -1316,6 +1316,27 @@ test_publish_system_trust_no_new_debris_on_success() {
     ! ls "$trust"/halos-ca.crt.new.* >/dev/null 2>&1 || { echo ".new.<pid> sibling should not remain after success"; return 1; }
 }
 
+test_publish_system_trust_failed_update_self_heals() {
+    # When update_cmd fails AFTER the cert is installed, the helper must remove
+    # the trust file — otherwise the next run's cmp short-circuit would skip the
+    # rebuild forever and the device would never trust its own CA.
+    local d="$TMPDIR_ROOT/case_systrust_selfheal"
+    local trust="$d/trust"
+    mkdir -p "$d"
+    halos_ca_ensure_auto "$d" || return 1
+    local bad="$d/fail-update"
+    printf '#!/bin/sh\nexit 1\n' > "$bad"; chmod +x "$bad"
+    halos_ca_publish_system_trust "$d/ca.crt" "$trust" "$bad" >/dev/null 2>&1
+    local rc=$?
+    assert_eq "$rc" "1" "update failure must return 1" || return 1
+    [ ! -f "$trust/halos-ca.crt" ] || { echo "trust file must be removed when update fails, so the next run retries"; return 1; }
+    # Retry with a succeeding update_cmd: must reinstall AND rebuild.
+    local good; good=$(_make_update_stub "$d")
+    halos_ca_publish_system_trust "$d/ca.crt" "$trust" "$good" || return 1
+    [ -f "$trust/halos-ca.crt" ] || { echo "trust file must be reinstalled on retry"; return 1; }
+    [ -f "$d/update-ran" ] || { echo "update must run on the retry, not be skipped"; return 1; }
+}
+
 # Decode the base64 <data> payload from a .mobileconfig into a DER file.
 # Pulls the single-line base64 between the <data> tags (our generator emits it
 # flattened), strips whitespace, and base64-decodes. Echoes the DER path.
@@ -1923,6 +1944,7 @@ run_test test_publish_system_trust_rejects_non_cert_source
 run_test test_publish_system_trust_preserves_existing_on_failure
 run_test test_publish_system_trust_refuses_directory_at_output
 run_test test_publish_system_trust_no_new_debris_on_success
+run_test test_publish_system_trust_failed_update_self_heals
 run_test test_publish_mobileconfig_happy_path
 run_test test_publish_mobileconfig_der_round_trips
 run_test test_publish_mobileconfig_embeds_display_host


### PR DESCRIPTION
## Why

A HaLOS device that runs its own desktop (HALPI2 desktop variants) didn't trust its own CA. Opening the local dashboard on the device's own screen showed cert warnings until the operator manually installed the CA — a regression of the expected default state.

Closes #158.

## What

`halos-manage-certs` now installs the active CA into `/usr/local/share/ca-certificates/halos-ca.crt` and runs `update-ca-certificates`, right after the existing public-CA publish. The device's own browser and CLI tools then validate its HTTPS endpoints with no operator action.

New helper `halos_ca_publish_system_trust` in `lib-ca.sh` mirrors `halos_ca_publish_public`: atomic stage+mv, X.509-parse validation, preserve-the-old-copy-on-failure. It **skips the `update-ca-certificates` rebuild when the store already holds the active CA**, so the 24 h renewal timer never churns the host bundle — only a CA rotation re-triggers it. Aux-failure semantics match the sibling publish steps: a failure logs `WARNING` and never blocks cert management.

Fires on the same triggers as the existing publish step: boot, CA rotation, sentinel change, the 24 h renewal timer.

## Scope notes

- Runs on **every variant**, not gated to desktop — installing the device's own CA is benign (and useful for local `curl`) on headless devices too. The issue's scope listed no variant gating.
- Touches `docs/CERTS.md` (new "Host self-trust" subsection) to keep the operator reference current — slightly beyond the issue's file list, called out here.

## Tests

- `tests/test-lib-ca.sh` — 9 new unit tests for the helper: happy path, skip-when-current, rebuild-on-rotation, missing args (rc 2), missing/non-cert source (rc 1), preserve-on-failure, directory-at-output, no `.new` debris.
- `tests/test-halos-manage-certs.sh` — 3 integration tests via the env-stub seam (`HALOS_SYSTEM_TRUST_DIR`, `HALOS_UPDATE_CA_CMD`): first boot installs + rebuilds, idempotent rerun skips the rebuild, CA rotation re-installs + rebuilds.

Full suite green (lib-ca 121, halos-manage-certs 38, pytest 25, all sibling suites). shellcheck clean (only pre-existing info-level findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)