### PR TITLE
docs(certs): macOS CA trust via Terminal command

### DIFF
--- a/assets/ca-download/www/ca/index.html
+++ b/assets/ca-download/www/ca/index.html
@@ -115,10 +115,9 @@
 
       <p class="caveat">
         In your operating system's trust store this CA appears as
-        <strong>HaLOS Device CA</strong>. Newer devices also show this device's
-        hostname, <code data-device-host>this device</code>, in parentheses —
-        handy when you manage several HaLOS devices and need to tell their
-        certificates apart (or remove a stale one).
+        <strong>HaLOS Device CA (<code data-device-host>this device</code>)</strong> —
+        the hostname in parentheses helps when you manage several HaLOS devices
+        and need to tell their certificates apart (or remove a stale one).
       </p>
 
       <div class="note">
@@ -132,13 +131,14 @@
       <details id="macos">
         <summary>macOS</summary>
         <ol>
-          <li>Download <a href="/ca/halos-ca.crt" download="halos-ca.crt"><code data-cert-filename>halos-ca.crt</code></a> (the button at the top does the same).</li>
-          <li>Double-click the downloaded file. Keychain Access opens and adds the certificate to the <strong>System</strong> keychain (choose System if it asks which keychain); enter an admin password if prompted.</li>
-          <li>It's installed but not yet trusted. In Keychain Access, select the <strong>System</strong> keychain, find <em>HaLOS Device CA</em> under <em>Certificates</em> (on newer devices it reads <em>HaLOS Device CA (<span data-device-host>this device</span>)</em>), and double-click it.</li>
-          <li>Expand <strong>Trust</strong> and set <em>Secure Sockets Layer (SSL)</em> (or <em>When using this certificate</em>) to <strong>Always Trust</strong>. Close the window and authenticate. <span class="caveat">macOS keeps install and trust separate — without this step the warnings stay.</span></li>
+          <li>Download <a href="/ca/halos-ca.crt" download="halos-ca.crt"><code data-cert-filename>halos-ca.crt</code></a> (the button at the top does the same). It lands in <code>~/Downloads</code> by default.</li>
+          <li>Open the <strong>Terminal</strong> app — press <kbd>⌘</kbd>+<kbd>Space</kbd>, type <em>Terminal</em>, and press <kbd>Return</kbd> — then type (or paste) this command and press <kbd>Return</kbd>:
+            <pre>sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain ~/Downloads/<span data-cert-filename>halos-ca.crt</span></pre>
+            Enter your password when prompted. <span class="caveat"><code>-d</code> installs into the admin/System domain; <code>-r trustRoot</code> trusts it as a root CA. This one command both imports and trusts the certificate, so there is no separate Keychain Access step.</span>
+          </li>
           <li>Quit and reopen your browser.</li>
         </ol>
-        <p class="caveat">On macOS the raw certificate is the reliable path: a certificate delivered by a configuration profile is not added to Keychain Access and cannot be granted SSL trust there, so the profile install (used on iPhone/iPad) does not help on a Mac.</p>
       </details>
 
       <details id="ios">
@@ -150,7 +150,7 @@
         </p>
         <ol>
           <li>Tap <strong>Download the install profile</strong> above in <strong>Safari</strong> and allow it. iOS shows <em>Profile Downloaded</em>. <span class="caveat">Use Safari — other browsers can't hand the profile to iOS.</span></li>
-          <li>Open <strong>Settings → General → VPN &amp; Device Management</strong>, tap the <em>HaLOS Device CA</em> profile (newer devices name it <em>HaLOS Device CA (<span data-device-host>this device</span>)</em>), then <strong>Install</strong> (enter your passcode). <span class="caveat">The profile is unsigned, so iOS marks it "Not Verified" — expected for your own device.</span></li>
+          <li>Open <strong>Settings → General → VPN &amp; Device Management</strong>, tap the <em>HaLOS Device CA (<span data-device-host>this device</span>)</em> profile, then <strong>Install</strong> (enter your passcode). <span class="caveat">The profile is unsigned, so iOS marks it "Not Verified" — expected for your own device.</span></li>
           <li><strong>Then</strong> open <strong>Settings → General → About → Certificate Trust Settings</strong> and turn on the toggle for the HaLOS CA. <span class="caveat">iOS 17/18 require this separate toggle — installing the profile alone does not trust it for websites.</span></li>
         </ol>
         <details>

--- a/tests/test_landing_content.py
+++ b/tests/test_landing_content.py
@@ -48,7 +48,7 @@ def test_macos_uses_raw_crt_not_profile():
     # must NOT offer the .mobileconfig.
     macos = _section("macos")
     assert 'href="/ca/halos-ca.crt"' in macos
-    assert "Always Trust" in macos
+    assert "add-trusted-cert" in macos
     assert "halos-ca.mobileconfig" not in macos
 
 
@@ -67,7 +67,7 @@ def test_ios_advanced_names_files_app_fallback():
 @pytest.mark.parametrize(
     "marker",
     [
-        "Always Trust",  # macOS Keychain trust step
+        "add-trusted-cert",  # macOS Terminal trust command
         "Certificate Trust Settings",  # iOS trust toggle
         "Android trusts user-installed CAs in browsers only",  # Android-unique
         "update-ca-certificates",  # Linux system store


### PR DESCRIPTION
## Why

The macOS section of the `/ca` install walkthrough told users to double-click the `.crt` into Keychain Access, pick the System keychain, then separately mark it *Always Trust*. On current macOS (Sequoia) that GUI path can pop the admin prompt and then silently do nothing — the import fails with no error, leaving the operator stuck with no signal.

## What

- **macOS now uses one Terminal command** — `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/Downloads/<cert>`. It both imports into the System keychain and marks the cert a trusted root, so the separate Keychain-Access import and *Always Trust* steps are gone. Verified on-device today against `<device>.local`.
- The command's filename uses the page's existing `data-cert-filename` placeholder (same convention as the Linux `sudo cp` block), so JS fills in the device-specific name (e.g. `halos-ca-<device>.local.crt`) from the `Content-Disposition` header — no hardcoded `halos-ca.crt`.
- Flags noted inline: `-d` = admin/System domain, `-r trustRoot` = trust as a root CA.
- The step walks the user into a terminal window (⌘-Space → Terminal → Return) rather than just dropping a command.
- **Naming cleanup:** dropped the "bare *HaLOS Device CA*" framing from the trust-store caveat and the iOS step. Devices ship the FQDN-qualified CN, so the copy now always shows the `HaLOS Device CA (<host>)` form.

## Scope

macOS GUI/trust steps only. The iOS `.mobileconfig` path and the Android / Linux / Windows sections are untouched.

## Tests

`tests/test_landing_content.py` guarded the old macOS step via the `Always Trust` marker; updated to `add-trusted-cert`. All 25 landing/tile content tests pass. No `VERSION` bump (docs/test change, per AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
