### PR TITLE
fix(ci): point release notes and README at apt.halos.fi

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -48,11 +48,11 @@ ${CHANGELOG}
 To install this pre-release:
 
 \`\`\`bash
-# Add Hat Labs repository (if not already added)
-curl -fsSL https://apt.hatlabs.fi/hat-labs-apt-key.asc | sudo gpg --dearmor -o /usr/share/keyrings/hatlabs-apt-key.gpg
+# Add HaLOS repository (if not already added)
+curl -fsSL https://apt.halos.fi/halos-apt-key.asc | sudo gpg --dearmor -o /usr/share/keyrings/halos.gpg
 
 # Add unstable channel
-echo "deb [signed-by=/usr/share/keyrings/hatlabs-apt-key.gpg] https://apt.hatlabs.fi unstable main" | sudo tee /etc/apt/sources.list.d/hatlabs-unstable.list
+echo "deb [signed-by=/usr/share/keyrings/halos.gpg] https://apt.halos.fi trixie-unstable main" | sudo tee /etc/apt/sources.list.d/halos.list
 
 # Update and install
 sudo apt update
@@ -80,7 +80,7 @@ ${CHANGELOG}
 
 ### Installation
 
-Built Debian packages are attached to this release and available from [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi):
+Built Debian packages are attached to this release and available from [apt.halos.fi](https://github.com/halos-org/apt.halos.fi):
 
 \`\`\`bash
 sudo apt update
@@ -113,7 +113,7 @@ ${CHANGELOG}
 
 ### Installation
 
-Built Debian packages are attached to this release and available from [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi):
+Built Debian packages are attached to this release and available from [apt.halos.fi](https://github.com/halos-org/apt.halos.fi):
 
 \`\`\`bash
 sudo apt update

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ CI/CD builds Debian packages from this repository:
 - `halos-authelia-container` - SSO identity provider
 - `halos-homarr-container` - Dashboard landing page
 
-All packages are published to apt.hatlabs.fi.
+All packages are published to apt.halos.fi.
 
 ## Agentic Coding Setup (Claude Code, GitHub Copilot, etc.)
 
@@ -202,7 +202,7 @@ ls build/*.deb
 - [halos-marine-containers](https://github.com/halos-org/halos-marine-containers) - Marine container store
 - [cockpit-apt](https://github.com/halos-org/cockpit-apt) - APT package manager with store filtering
 - [container-packaging-tools](https://github.com/halos-org/container-packaging-tools) - Package generation tooling
-- [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi) - APT repository infrastructure
+- [apt.halos.fi](https://github.com/halos-org/apt.halos.fi) - APT repository infrastructure
 
 ## License
 


### PR DESCRIPTION
## Motivation

When this repo moved from `hatlabs` to `halos-org`, it started publishing packages to `apt.halos.fi` (the `release.yml` workflow dispatches to the default `halos-org/apt.halos.fi`). But the org-migration commit missed the APT repository references in the release-notes generator and the README, so published release notes told users to add the **wrong repository and the wrong signing key** (`apt.hatlabs.fi` / `hat-labs-apt-key.asc`).

This surfaced while publishing the CA-certificate epic release `v0.4.3+10`, whose generated notes pointed at `apt.hatlabs.fi`. That release body was corrected by hand; this fixes the generator so it stops recurring.

## Approach

- `generate-release-notes.sh`: pre-release install block now uses the `apt.halos.fi` key (`halos-apt-key.asc` → `/usr/share/keyrings/halos.gpg`), the `trixie-unstable` channel, and `halos.list`; the two "available from" links point at `halos-org/apt.halos.fi`.
- `README.md`: the publish target line and the infrastructure link updated to `apt.halos.fi`.

Channel names and keyring path match the canonical install snippet in `apt.halos.fi/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)