### PR TITLE
docs(sso): correct auth-mode labels for Grafana, InfluxDB, Signal K

### DIFF
--- a/docs/SSO_ARCHITECTURE.md
+++ b/docs/SSO_ARCHITECTURE.md
@@ -22,7 +22,7 @@ The SSO architecture provides unified authentication for all HaLOS web applicati
          v              v              v              v
    ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
    │  Homarr  │   │ Grafana  │   │ InfluxDB │   │ Signal K │
-   │  (OIDC)  │   │ (FwdAuth)│   │ (FwdAuth)│   │(host net)│
+   │  (OIDC)  │   │  (OIDC)  │   │ (no SSO) │   │  (OIDC)  │
    └──────────┘   └──────────┘   └──────────┘   └──────────┘
          │              │              │              │
          └──────────────┴──────────────┴──────────────┘
@@ -476,9 +476,9 @@ traefik-container
        │
        └── application containers
             ├── homarr-container (OIDC)
-            ├── grafana-container (ForwardAuth)
-            ├── influxdb-container (ForwardAuth)
-            └── signalk-container (ForwardAuth, host networking)
+            ├── grafana-container (OIDC)
+            ├── influxdb-container (no SSO)
+            └── signalk-container (OIDC, host networking)
 ```
 
 Package dependencies ensure correct installation order. Systemd service dependencies ensure correct startup order.


### PR DESCRIPTION
## What

Correct the auth-mode labels in `docs/SSO_ARCHITECTURE.md` so they match the app metadata:

| App | Diagram/tree said | Actual (`metadata.yaml`) |
|---|---|---|
| Grafana | ForwardAuth | `routing.auth.mode: oidc` |
| InfluxDB | ForwardAuth | `routing.auth.mode: none` |
| Signal K | ForwardAuth | `routing.auth.mode: oidc` |

Homarr was already correct (OIDC). Four labels changed across the top diagram and the deployment-dependency tree.

## Why

The diagram predates the OIDC migration and mislabels three apps. InfluxDB in particular has no SSO edge gate — its own login is the only protection — which is easy to miss when the doc claims ForwardAuth.

## Not in scope

Deeper stale content still contradicts the corrected labels: the ForwardAuth flow sequence diagram built on Grafana, the example `grafana.yml` forwardAuth middleware, and the Signal K host-net ForwardAuth flow. Tracked in #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zURudCY3TTRcNd2acknJ9
