### PR TITLE
Stop first boot from needing a second Authelia image

### DIFF
--- a/assets/lib-oidc-clients.sh
+++ b/assets/lib-oidc-clients.sh
@@ -206,10 +206,13 @@ $(echo -e "${redirect_uris}" | sed '/^$/d')
     fi
 
     local tmp_file
-    tmp_file=$(mktemp "${AUTHELIA_OIDC_FILE}.XXXXXX") || return 1
+    tmp_file=$(mktemp "${AUTHELIA_OIDC_FILE}.tmp.XXXXXX") || return 1
     # The temp file holds the HMAC secret and the signing key, and lives in the
-    # directory bind-mounted as Authelia's /config.
-    trap 'rm -f "$tmp_file"' RETURN
+    # directory bind-mounted as Authelia's /config. RETURN alone would leave it
+    # behind whenever the shell is killed rather than returning — a shutdown
+    # mid-merge, a start timeout — so the signals are trapped too. SIGKILL and
+    # power loss still escape; halos_oidc_merge_clients sweeps for those.
+    trap 'rm -f "$tmp_file"' RETURN INT TERM HUP
     chmod 600 "$tmp_file"
 
     # Writes are checked explicitly: this function runs as an `if` condition, so
@@ -289,6 +292,14 @@ halos_oidc_merge_clients() {
     local stamp_file="${AUTHELIA_OIDC_FILE}.stamp"
 
     _halos_oidc_lock
+
+    # Sweep temp renders a previous run could not clean up — killed by SIGKILL,
+    # or by power loss. They are mode 0600 but hold the HMAC secret and the
+    # signing key, in the directory bind-mounted as Authelia's /config. This
+    # runs under the lock and before the digest short-circuit below, so it
+    # covers every path out of the merge, including the ones that never render.
+    # The .tmp. infix keeps the pattern off .lock and .stamp.
+    rm -f "${AUTHELIA_OIDC_FILE}".tmp.*
 
     local input_digest output_digest
     input_digest="$(_halos_oidc_input_digest)"

--- a/debian/halos-core-containers.service
+++ b/debian/halos-core-containers.service
@@ -16,6 +16,12 @@ EnvironmentFile=-/run/container-apps/halos-core-containers/runtime.env
 EnvironmentFile=-/run/halos/domain.env
 ExecStart=docker compose up
 ExecStop=docker compose down
+# Type=simple counts the unit as started once ExecStart forks, so this bounds
+# prestart.sh. On a first boot prestart generates a 4096-bit OIDC signing key
+# and runs Authelia's hashing container, which on a cold image cache means a
+# registry fetch first — none of that fits systemd's 90 s default, and the
+# timeout kills prestart mid-render.
+TimeoutStartSec=600
 Restart=on-failure
 RestartSec=10
 StandardOutput=journal

--- a/docs/SSO_ARCHITECTURE.md
+++ b/docs/SSO_ARCHITECTURE.md
@@ -58,7 +58,7 @@ Traefik is the central routing component. It receives all incoming HTTP/HTTPS re
 
 ### Authelia Identity Provider
 
-**Image**: `authelia/authelia:4.39`
+**Image**: pinned in `docker-compose.yml` (and mirrored by `HALOS_OIDC_AUTHELIA_IMAGE` in `assets/lib-oidc-clients.sh`, which is what prestart and the reload tool hash with)
 **Network**: `halos-proxy-network` (external)
 **Ports**: None exposed (accessed via Traefik)
 

--- a/prestart.sh
+++ b/prestart.sh
@@ -444,11 +444,23 @@ echo "REDIS_PASSWORD=${REDIS_PASSWORD}" >> "${RUNTIME_ENV}"
 if [ ! -f "${AUTHELIA_DATA}/users_database.yml" ]; then
     echo "Creating initial admin user..."
     DEFAULT_PASSWORD="halos"
-    INITIAL_HASH=$(docker run --rm authelia/authelia:4.39 authelia crypto hash generate argon2 \
-        --password "${DEFAULT_PASSWORD}" 2>/dev/null | grep 'Digest:' | sed 's/Digest: //')
+    # Plaintext through the environment, not argv: /proc/<pid>/cmdline is
+    # world-readable, and this is the pattern _halos_oidc_hash_secret uses for
+    # the same CLI. Docker's own output is kept: without it an unreachable
+    # registry, a rate-limited pull and a stopped daemon all reduce to one
+    # generic line, with the whole stack down and nothing to attribute it to.
+    if ! HASH_OUTPUT=$(HALOS_ADMIN_PW="${DEFAULT_PASSWORD}" docker run --rm \
+        -e HALOS_ADMIN_PW "${HALOS_OIDC_AUTHELIA_IMAGE}" \
+        sh -c 'authelia crypto hash generate argon2 --password "$HALOS_ADMIN_PW"' 2>&1); then
+        echo "ERROR: could not generate the initial password hash" >&2
+        printf 'docker: %s\n' "${HASH_OUTPUT}" >&2
+        exit 1
+    fi
+    INITIAL_HASH=$(printf '%s\n' "${HASH_OUTPUT}" | grep 'Digest:' | sed 's/Digest: //')
 
     if [ -z "${INITIAL_HASH}" ]; then
-        echo "ERROR: Failed to generate password hash"
+        echo "ERROR: password hashing produced no digest" >&2
+        printf 'docker: %s\n' "${HASH_OUTPUT}" >&2
         exit 1
     fi
 

--- a/tests/test-lib-oidc-clients.sh
+++ b/tests/test-lib-oidc-clients.sh
@@ -238,6 +238,98 @@ test_merge_renders_clients() {
     assert_not_contains "$out" '${HALOS_DOMAIN}' "placeholder left unexpanded"
 }
 
+# Name a leftover the way _halos_oidc_render's mktemp template does, so the
+# fixture tracks the renderer rather than the sweep's own glob.
+plant_stale_render() {
+    local root="$1"
+    local stale="$(authelia_dir "$root")/oidc-clients.yml.tmp.AbC123"
+    echo "hmac_secret: 'leaked-from-a-killed-render'" > "$stale"
+    printf '%s' "$stale"
+}
+
+test_merge_sweeps_temp_render_from_a_killed_run() {
+    new_device; local root="$DEV_ROOT"
+    write_client "$root" "signalk" "sekrit-one"
+    local stale; stale="$(plant_stale_render "$root")"
+    # Siblings the sweep must not claim. SIGKILL leaves the lock behind too, and
+    # unlinking it while a flock is held lets a second merge run concurrently.
+    local lock="$(authelia_dir "$root")/oidc-clients.yml.lock"
+    local stamp="$(authelia_dir "$root")/oidc-clients.yml.stamp"
+    : > "$lock"; echo "planted" > "$stamp"
+
+    merge_on "$root" > /dev/null
+    [ ! -e "$stale" ] || { echo "    a killed run's temp render survived the merge"; return 1; }
+    [ -e "$lock" ] || { echo "    sweep unlinked the merge lock"; return 1; }
+    [ -e "$stamp" ] || { echo "    sweep unlinked the stamp"; return 1; }
+    assert_contains "$(cat "$(authelia_dir "$root")/oidc-clients.yml")" "client_id: signalk" \
+        "the render itself must still land"
+}
+
+# The library pins the hashing image to the tag docker-compose.yml runs, so a
+# device never fetches a second Authelia image. Nothing enforced that, and the
+# two drifted once already (#210): prestart pulled 4.39 while the stack ran
+# 4.39.19, so an unreachable registry took the whole stack down on first boot.
+test_hashing_image_matches_the_compose_pin() {
+    local lib_tag compose_tag
+    lib_tag=$(sed -n 's/^HALOS_OIDC_AUTHELIA_IMAGE="\(.*\)"$/\1/p' "$LIB_OIDC" | head -1)
+    compose_tag=$(sed -n 's/^[[:space:]]*image:[[:space:]]*\(authelia\/authelia:.*\)$/\1/p' \
+        "$REPO_ROOT/docker-compose.yml" | head -1)
+    assert_eq "$lib_tag" "$compose_tag" "the hashing image must be the tag the stack runs" || return 1
+
+    if grep -qE 'authelia/authelia:' "$REPO_ROOT/prestart.sh"; then
+        echo "    prestart.sh names an Authelia tag directly; it must use \$HALOS_OIDC_AUTHELIA_IMAGE"
+        return 1
+    fi
+}
+
+# The fixtures above name a leftover by hand, so they cannot see the renderer's
+# template drifting away from the sweep's glob — the sweep would then match
+# nothing a real killed run leaves. Pin the two to each other, and to the
+# siblings they must never claim.
+test_sweep_glob_matches_what_the_renderer_creates() {
+    local template sweep produced
+    template=$(sed -n 's/.*mktemp "${AUTHELIA_OIDC_FILE}\(\.[^"]*\)".*/\1/p' "$LIB_OIDC" | head -1)
+    sweep=$(sed -n 's/.*rm -f "${AUTHELIA_OIDC_FILE}"\(\.[^ ]*\).*/\1/p' "$LIB_OIDC" | head -1)
+    [ -n "$template" ] || { echo "    no mktemp template found in $LIB_OIDC"; return 1; }
+    [ -n "$sweep" ] || { echo "    no sweep pattern found in $LIB_OIDC"; return 1; }
+
+    produced="${template//XXXXXX/AbC123}"
+    # shellcheck disable=SC2254  # $sweep is a glob on purpose
+    case "$produced" in
+        $sweep) ;;
+        *) echo "    mktemp creates '${produced}' but the sweep looks for '${sweep}'"; return 1 ;;
+    esac
+    for sibling in .lock .stamp; do
+        # shellcheck disable=SC2254
+        case "$sibling" in
+            $sweep) echo "    the sweep pattern '${sweep}' also claims '${sibling}'"; return 1 ;;
+        esac
+    done
+}
+
+test_merge_sweeps_when_nothing_needs_rendering() {
+    new_device; local root="$DEV_ROOT"
+    write_client "$root" "signalk" "sekrit-one"
+    merge_on "$root" > /dev/null
+
+    # Inputs now match the stamp, so the merge short-circuits without rendering.
+    # A sweep that lived in the renderer would never run again on this device.
+    local stale; stale="$(plant_stale_render "$root")"
+    merge_on "$root" > /dev/null
+    [ ! -e "$stale" ] || { echo "    an unchanged merge left the temp render in place"; return 1; }
+}
+
+test_merge_sweeps_when_hashing_fails() {
+    new_device; local root="$DEV_ROOT"
+    write_client "$root" "signalk" "sekrit-one"
+    local stale; stale="$(plant_stale_render "$root")"
+
+    # Hashing failure is the registry-unreachable path, which is also the one
+    # most likely to have produced the leftover in the first place.
+    DOCKER_STUB_HASH_RC=1 merge_on "$root" > /dev/null 2>&1 || true
+    [ ! -e "$stale" ] || { echo "    a failed merge left the temp render in place"; return 1; }
+}
+
 test_merge_reports_change_on_first_render() {
     new_device; local root="$DEV_ROOT"
     write_client "$root" "signalk" "sekrit-one"
@@ -721,6 +813,11 @@ test_reload_aborts_without_authelia_secrets() {
 # ---------------------------------------------------------------------------
 
 run_test test_merge_renders_clients
+run_test test_merge_sweeps_temp_render_from_a_killed_run
+run_test test_hashing_image_matches_the_compose_pin
+run_test test_sweep_glob_matches_what_the_renderer_creates
+run_test test_merge_sweeps_when_nothing_needs_rendering
+run_test test_merge_sweeps_when_hashing_fails
 run_test test_merge_reports_change_on_first_render
 run_test test_merge_without_snippets_disables_oidc
 run_test test_merge_skips_snippet_without_secret_file


### PR DESCRIPTION
First boot fetched a second Authelia image that only one line needed, and could be killed by systemd's default start timeout while doing it. Both failures land as "the whole web stack is down", the symptom that points nowhere.

Issue #210 is addressed here but deliberately left open — its stated verification is a cold boot on freshly flashed hardware, which this branch has not had.

## Changes

**The admin-password hash uses the pinned image.** `prestart.sh` hard-coded `authelia/authelia:4.39` while `docker-compose.yml` and `lib-oidc-clients.sh` both run `4.39.19`. The library already carries the constant and states the intent — "Pinned to the tag docker-compose.yml runs, so the device never has to pull, retain, or reach a registry for a second image" — and prestart sources that library, so it now uses `HALOS_OIDC_AUTHELIA_IMAGE`. Docker's own stderr is kept rather than discarded: without it an unreachable registry, a rate-limited pull and a stopped daemon all reduce to one generic line. The plaintext moves from argv to the environment, matching `_halos_oidc_hash_secret`.

**`TimeoutStartSec=600` on the stack.** `Type=simple` counts the unit started once `ExecStart` forks, so the timeout bounds `prestart.sh`. A first boot generates a 4096-bit signing key and runs Authelia's hashing container, pulling the image on a cold cache — none of which fits the 90 s default on a Pi.

**Temp renders survive neither a signal nor a later run.** `_halos_oidc_render` cleaned its `mktemp` file from a `RETURN` trap, which does not fire when the shell is killed — a shutdown mid-merge left a 0600 file holding the HMAC secret and the signing key in the directory bind-mounted as Authelia's `/config`. The trap now covers `INT TERM HUP`, and a sweep at the top of `halos_oidc_merge_clients` — under the lock, before the digest short-circuit — catches what SIGKILL and power loss leave behind. Temp renders get a `.tmp.` infix so the sweep pattern cannot reach the `.lock` or `.stamp` beside them.

## Verification

`tests/test-lib-oidc-clients.sh` grew four assertions, 39/39 green. Each was mutation-tested against the branch:

| Mutation | Caught by |
|---|---|
| sweep moved back inside `_halos_oidc_render` | `..._when_nothing_needs_rendering`, `..._when_hashing_fails` |
| sweep glob widened to `.*` (unlinks the merge lock) | `..._from_a_killed_run` + 2 pre-existing tests |
| `mktemp` template drifts away from `.tmp.` | `test_sweep_glob_matches_what_the_renderer_creates` |
| prestart names an Authelia tag directly again | `test_hashing_image_matches_the_compose_pin` |

The first three all passed before this round — the original test planted a filename matching the sweep's own glob and asserted only a count, so it could not see any of them.

Still unverified: the cold first boot itself (empty image cache, no secrets, no stamp). `TimeoutStartSec=600` is bracketed by "more than 90" on one side and nothing on the other; no timing exists for prestart on a Pi with a cold cache.

Note for whoever merges: #215 touches the same unit file. Its earlier `StartLimitIntervalSec=300` would have made this timeout defeat it — a 610 s attempt cycle never fills a 300 s burst window — but #215 now uses `RestartSteps`/`RestartMaxDelaySec` instead, which has no such coupling.

No `VERSION` bump: latest stable is `v0.7.0+1` and `VERSION` is already 0.7.1, so the cycle is open.
