### PR TITLE
Do not let a failed input unit silently cancel the core stack

### DIFF
--- a/debian/halos-core-containers.halos-manage-certs.service
+++ b/debian/halos-core-containers.halos-manage-certs.service
@@ -8,11 +8,12 @@ Before=halos-core-containers.service
 # Type=oneshot WITHOUT RemainAfterExit so the timer's `start` action
 # actually re-runs ExecStart on each fire. systemd's `start` on a
 # RemainAfterExit=yes oneshot in active(exited) state is a documented
-# no-op, which would silently break periodic renewal. The Requires= +
-# After= chain on halos-core-containers.service still gates correctly:
-# a successfully-exited oneshot satisfies Requires= even after it goes
-# naturally inactive (verified empirically — only failed exits drop
-# the consumer).
+# no-op, which would silently break periodic renewal. The ordering
+# against halos-core-containers.service still holds: a successfully-exited
+# oneshot satisfies After= even after it goes naturally inactive. The stack
+# only Wants= this unit, though, so a failed run no longer holds the stack
+# back — it starts with whatever TLS material exists and the timer below is
+# what repairs it (#212).
 Type=oneshot
 ExecStart=/usr/lib/halos-core-containers/halos-manage-certs
 StandardOutput=journal

--- a/debian/halos-core-containers.halos-manage-certs.timer
+++ b/debian/halos-core-containers.halos-manage-certs.timer
@@ -11,14 +11,16 @@ OnBootSec=15min
 # Re-check every 24h. Well below HALOS_CA_LEAF_RENEW_THRESHOLD_DAYS (60d),
 # so even fortnightly-rebooted devices get multiple chances to renew.
 OnUnitActiveSec=24h
-# Spread fleet-wide hits over a 1h window to avoid synchronized renewal
-# storms.
+# Spread the hits from every device with this package over a 1h window to
+# avoid synchronized renewal storms. Note this delays the first post-boot
+# check to 15-75 min, which is also how long a boot-time cert failure goes
+# unrepaired.
 RandomizedDelaySec=1h
 # Deliberately NOT Persistent=true: Raspberry Pi has no RTC, so first
 # boot starts with a fake-hwclock timestamp (often 1970). With Persistent
 # set, the post-NTP clock jump from 1970 → 2026 would trigger a catch-up
 # fire storm of "missed" runs. Boot-time renewal still happens because
-# halos-core-containers.service Requires= halos-manage-certs.service —
+# halos-core-containers.service pulls this unit in via Wants= —
 # losing Persistent only means a device powered off across a scheduled
 # fire waits for the next OnUnitActiveSec=24h tick (≤24h post-boot) to
 # re-check, which is well below the 60-day renewal threshold.

--- a/debian/halos-core-containers.halos-resolve-domain.service
+++ b/debian/halos-core-containers.halos-resolve-domain.service
@@ -7,14 +7,22 @@ Before=halos-core-containers.service
 [Service]
 # Type=oneshot WITHOUT RemainAfterExit so an explicit consumer (re)start
 # re-runs the resolver and republishes /run/halos/domain.env, picking up admin
-# edits to /etc/halos/hostnames.conf. A consumer's Requires= pulls in this
-# (inactive) oneshot when the consumer is started; the successful exit
-# satisfies Requires= even after the unit goes naturally inactive. (A systemd
-# Restart=on-failure auto-restart of the consumer does not re-pull Requires=
-# deps, so it does not re-run this — domain.env simply retains its last value.)
+# edits to /etc/halos/hostnames.conf. A consumer's Wants= pulls in this
+# (inactive) oneshot when the consumer is started, and a successfully-exited
+# oneshot still satisfies the ordering after it goes naturally inactive. (A
+# systemd auto-restart of the consumer does not re-pull its dependencies, so it
+# does not re-run this — domain.env simply retains its last value.)
 # Same reasoning as halos-manage-certs.service.
 Type=oneshot
 ExecStart=/usr/lib/halos-core-containers/halos-resolve-domain
+# The consumer refuses to start without the domain this publishes, and an
+# auto-restart of the consumer will not re-run this unit. Retry here instead, so
+# a transient failure heals on its own: the resolver republishes, and the
+# consumer's next backed-off retry finds the file.
+Restart=on-failure
+RestartSec=30
+RestartSteps=4
+RestartMaxDelaySec=300
 StandardOutput=journal
 StandardError=journal
 

--- a/debian/halos-core-containers.service
+++ b/debian/halos-core-containers.service
@@ -1,7 +1,18 @@
 [Unit]
 Description=HaLOS Core Containers (Traefik, Authelia, Homarr)
 After=docker.service halos-manage-certs.service halos-resolve-domain.service
-Requires=docker.service halos-manage-certs.service halos-resolve-domain.service
+# docker is the runtime -- without it there is nothing to run, so it stays a
+# hard requirement. The two oneshots produce inputs instead, and Requires= on
+# them is a trap: a failed dependency cancels this unit's start job, so the unit
+# never runs ExecStart and ends inactive with Result=success, invisible to
+# `systemctl --failed`, while the whole web stack is absent. Nothing re-queues
+# it either -- measured: a dependency with Restart=on-failure that retries to
+# success does not bring the cancelled consumer back (#212). Wants= keeps the
+# ordering, lets the stack start, and leaves the failure visible on the unit
+# that actually failed; prestart refuses to run without the domain the resolver
+# publishes, so a genuinely missing input still fails loudly here.
+Requires=docker.service
+Wants=halos-manage-certs.service halos-resolve-domain.service
 
 [Service]
 Type=simple
@@ -17,7 +28,16 @@ EnvironmentFile=-/run/halos/domain.env
 ExecStart=docker compose up
 ExecStop=docker compose down
 Restart=on-failure
+# Back the retries off rather than capping them. A start limit would put the
+# unit in `failed` and leave it there -- nothing here re-queues it, so a cause
+# that clears later (the network arrives, the docker daemon finishes
+# restarting) would need a human, on a device that is usually headless. Retry
+# forever instead, but stop hammering: 10 s, doubling to a 5 min ceiling, so a
+# stack that cannot start logs its reason a few times an hour rather than every
+# 10 s, and comes up on its own the moment the cause goes away.
 RestartSec=10
+RestartSteps=6
+RestartMaxDelaySec=300
 StandardOutput=journal
 StandardError=journal
 

--- a/docs/solutions/2026-08-10-requires-on-a-failable-unit-cancels-the-consumer.md
+++ b/docs/solutions/2026-08-10-requires-on-a-failable-unit-cancels-the-consumer.md
@@ -1,0 +1,80 @@
+---
+title: "Requires= on a unit that can fail cancels the consumer's start job"
+date: 2026-08-10
+repo: halos-core-containers
+pr: https://github.com/halos-org/halos-core-containers/pull/215
+tags: [systemd, requires, wants, oneshot, restart, backoff, boot, gotcha, knowledge]
+---
+
+# Context
+
+`halos-core-containers.service` hard-required two `Type=oneshot` units that
+produce its inputs:
+
+```ini
+Requires=docker.service halos-manage-certs.service halos-resolve-domain.service
+```
+
+If either oneshot exits non-zero, the stack does **not** fail. It is never
+started at all: `journalctl -u halos-core-containers.service -b` is empty,
+`systemctl show` reports `ActiveState=inactive` with `Result=success`, and
+`systemctl --failed` does not list it — while Traefik, Authelia and Homarr are
+all absent. The only visible failure is the dependency itself, which reads as a
+bystander.
+
+# What was measured
+
+Scratch units in `/run/systemd/system` on a HALPI2 (systemd 257, Debian trixie):
+
+| Setup | Result |
+|---|---|
+| consumer `Requires=` a oneshot that fails | consumer `inactive`, `Result=success`, `ExecMainStartTimestamp` empty — ExecStart never ran |
+| same, but the oneshot has `Restart=on-failure` and succeeds on attempt 3 | oneshot reached success; **consumer still never ran** |
+| consumer `Wants=` + `After=` a oneshot that fails | consumer `active`, started 1.8 ms after the dependency finished; failed dependency listed in `systemctl --failed` |
+
+The second row is the counter-intuitive one, and it kills the obvious fix:
+once a start job is cancelled, nothing re-queues it. Adding retries to the
+dependency does not help the consumer.
+
+# The rule
+
+`Requires=` for a **runtime** the unit cannot execute without (here:
+`docker.service`). `Wants=` + `After=` for a unit that **produces an input** —
+plus a check in the consumer for the input it genuinely cannot run without, so
+a missing input fails loudly in the consumer's own journal instead of rendering
+an empty value.
+
+# Restart limits are not the answer either
+
+The first fix attempt added `StartLimitIntervalSec=300` / `StartLimitBurst=6`
+so an unbootable stack would stop looping and reach `failed`. Two problems:
+
+- **It makes failure permanent.** Nothing re-queues a start-limit `failed` unit
+  — no `OnFailure=`, no timer. A cause that clears later (network arrives,
+  docker daemon finishes restarting) then needs a human, on a headless device.
+- **The window interacts with the start timeout.** systemd's rate limiter
+  resets its counter when an attempt arrives more than `interval` after the
+  window opened. With `TimeoutStartSec=600` and `RestartSec=10`, an attempt
+  cycle is ~610 s, so no two attempts ever fall inside a 300 s window and the
+  burst never fills — a *hanging* start loops forever anyway. A limit only
+  bounds failures faster than `StartLimitIntervalSec / StartLimitBurst`.
+
+Backing the retries off does the job without either flaw:
+
+```ini
+Restart=on-failure
+RestartSec=10
+RestartSteps=6
+RestartMaxDelaySec=300
+```
+
+Retries forever (so it self-heals), with the delay doubling to a 5-minute
+ceiling (so it stops hammering), and no coupling to `TimeoutStartSec`.
+`RestartSteps=` / `RestartMaxDelaySec=` need systemd 254+; trixie ships 257.
+
+# Diagnosis
+
+A stack that is absent with an empty `journalctl -u <unit> -b` is this bug, not
+a crash. Check `systemctl show <unit> -p Result` — `success` on a unit that
+never ran means its job was cancelled, and the cause is a failed `Requires=`
+dependency, which `systemctl --failed` will name.

--- a/prestart.sh
+++ b/prestart.sh
@@ -58,6 +58,22 @@ cat > "${RUNTIME_ENV}" << EOF
 HOSTNAME=${HOSTNAME_SHORT}
 EOF
 
+# An empty HALOS_DOMAIN renders into the OIDC issuer, Authelia's cookie domain
+# and Traefik's redirects, producing a stack that looks healthy and whose every
+# login fails. Since the resolver is only wanted by this unit, not required, the
+# stack now starts even when it failed, so refuse here instead.
+#
+# The resolver's file is checked, not just the variable: /run is tmpfs so a
+# stale domain.env cannot outlive a reboot, but an in-place upgrade can leave a
+# pre-upgrade HALOS_DOMAIN in runtime.env, which must not satisfy this.
+#
+# Both units retry with backoff, so a transient resolver failure heals without
+# help: the resolver republishes and a later retry here picks it up.
+if [ ! -s /run/halos/domain.env ] || [ -z "${HALOS_DOMAIN:-}" ]; then
+    echo "HALOS_DOMAIN_UNSET: halos-resolve-domain.service has not published /run/halos/domain.env" >&2
+    exit 1
+fi
+
 echo "HaLOS Core Containers prestart"
 echo "Domain: ${HALOS_DOMAIN}"
 

--- a/prestart.sh
+++ b/prestart.sh
@@ -100,6 +100,25 @@ fi
 
 # TLS leaf + CA artifacts are provisioned by a separate unit; see docs/CERTS.md.
 
+# The ca-download sidecar bind-mounts the adoption sentinel as a *file*, and
+# halos-manage-certs.service is what normally creates it — but the stack only
+# Wants= that unit now, so a failed cert run would let Docker create a directory
+# at the mount source instead. lib-ca.sh then repairs the host path on its next
+# successful run while the running sidecar keeps the removed inode mounted, so
+# adoption is never recorded and the CN-refresh gate can orphan a trust anchor
+# the operator already installed. Guarantee the file here, with the same call
+# the cert manager makes: an existing sentinel is preserved verbatim, and with
+# no auto-CA yet the value is the documented fail-safe ("adopted", CN frozen).
+LIB_CA="/usr/lib/halos-core-containers/lib-ca.sh"
+if [ ! -f "$LIB_CA" ]; then
+    LIB_CA="${SCRIPT_DIR}/assets/lib-ca.sh"
+fi
+# shellcheck source=assets/lib-ca.sh
+. "$LIB_CA"
+AUTO_CA_DIR="${CONTAINER_DATA_ROOT}/${PACKAGE_NAME}/certs/ca"
+halos_ca_adoption_init "${AUTO_CA_DIR}/adoption" "${AUTO_CA_DIR}/ca.crt" 0
+chown "${HALOS_CA_DOWNLOAD_UID}:${HALOS_CA_DOWNLOAD_UID}" "${AUTO_CA_DIR}/adoption" 2>/dev/null || true
+
 # Dynamic Configuration Directory
 DYNAMIC_DIR="/etc/halos/traefik-dynamic.d"
 DYNAMIC_SRC_DIR="${SCRIPT_DIR}/assets/traefik/dynamic"

--- a/tests/test-packaging-contract.sh
+++ b/tests/test-packaging-contract.sh
@@ -23,6 +23,11 @@
 #    for a release (#208). The unit files are the only place this invariant
 #    lives; systemd-analyze verify does not see it, because a cycle exists only
 #    in a boot transaction.
+#
+# 4. A failed Requires= dependency does not fail the consumer — it deletes the
+#    consumer's start job, which ends inactive with Result=success and never
+#    appears in `systemctl --failed`. The core stack spent a release in that
+#    state (#212). The two input oneshots must stay Wants=.
 
 set -u
 set -o pipefail
@@ -90,7 +95,34 @@ for unit in "$REPO_ROOT"/debian/${PKG}.*.path; do
     fi
 done
 
-# 4. Shared shell libraries reach /usr/lib/<pkg>/, where both callers source
+# 4. The stack requires the container runtime and only wants the units that
+#    produce its inputs. The loops above glob debian/${PKG}.*.{service,timer,path}
+#    and so never see the main unit, which is why this names the file.
+STACK_UNIT="$REPO_ROOT/debian/${PKG}.service"
+stack_requires=$(grep -h '^Requires=' "$STACK_UNIT" | cut -d= -f2-)
+stack_wants=$(grep -h '^Wants=' "$STACK_UNIT" | cut -d= -f2-)
+stack_after=$(grep -h '^After=' "$STACK_UNIT" | cut -d= -f2-)
+
+for oneshot in halos-manage-certs.service halos-resolve-domain.service; do
+    if [[ " $stack_requires " == *" $oneshot "* ]]; then
+        fail "${PKG}.service Requires=${oneshot}; a failed run would cancel the stack's start job silently (#212)"
+    elif [[ " $stack_wants " != *" $oneshot "* ]]; then
+        fail "${PKG}.service neither Requires= nor Wants= ${oneshot}; it would never be pulled in"
+    else
+        pass "${PKG}.service wants ${oneshot} rather than requiring it"
+    fi
+    if [[ " $stack_after " != *" $oneshot "* ]]; then
+        fail "${PKG}.service is not ordered After=${oneshot}; the input may not exist yet"
+    fi
+done
+
+if [[ " $stack_requires " == *" docker.service "* ]]; then
+    pass "${PKG}.service still requires docker.service"
+else
+    fail "${PKG}.service does not Requires=docker.service; without the runtime there is nothing to run"
+fi
+
+# 5. Shared shell libraries reach /usr/lib/<pkg>/, where both callers source
 #    them from. A library that ships only inside the app directory would break
 #    /usr/bin/reload-oidc-clients while leaving prestart working.
 for lib in "$REPO_ROOT"/assets/lib-*.sh; do

--- a/tests/test-prestart-loader-contract.sh
+++ b/tests/test-prestart-loader-contract.sh
@@ -5,7 +5,7 @@
 #   bash tests/test-prestart-loader-contract.sh
 #
 # AGENTS.md: the shared loaders under /usr/lib/halos-core-containers/
-# (lib-hostnames.sh, lib-oidc-clients.sh) are sourced by prestart.sh — "do not
+# (lib-hostnames.sh, lib-oidc-clients.sh, lib-ca.sh) are sourced by prestart.sh — "do not
 # duplicate parsing logic — extend the loader instead."
 #
 # prestart.sh runs under `set -e`, so any halos_* / _halos_* function it
@@ -23,8 +23,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PRESTART="$REPO_ROOT/prestart.sh"
 LIB="$REPO_ROOT/assets/lib-hostnames.sh"
 LIB_OIDC="$REPO_ROOT/assets/lib-oidc-clients.sh"
+LIB_CA="$REPO_ROOT/assets/lib-ca.sh"
 
-for f in "$PRESTART" "$LIB" "$LIB_OIDC"; do
+for f in "$PRESTART" "$LIB" "$LIB_OIDC" "$LIB_CA"; do
     [ -f "$f" ] || { echo "missing fixture: $f" >&2; exit 2; }
 done
 
@@ -56,6 +57,9 @@ check_sources_loader() {
 }
 check_sources_loader LIB_HOSTNAMES 'lib-hostnames\.sh'
 check_sources_loader LIB_OIDC_CLIENTS 'lib-oidc-clients\.sh'
+# prestart guarantees the ca-download adoption sentinel exists as a regular file
+# before compose binds it, using the cert manager's own initializer.
+check_sources_loader LIB_CA 'lib-ca\.sh'
 
 # 2. Every loader symbol prestart.sh *invokes* must be defined by the loader.
 #    Collect candidate invocations: halos_* / _halos_* tokens that appear as a
@@ -70,6 +74,8 @@ mapfile -t called < <(grep -oE '\b_?halos_[a-z_]+' "$PRESTART" \
 . "$LIB"
 # shellcheck source=/dev/null
 . "$LIB_OIDC"
+# shellcheck source=/dev/null
+. "$LIB_CA"
 
 missing=()
 for fn in "${called[@]}"; do
@@ -84,7 +90,7 @@ if [ "${#called[@]}" -gt 0 ] && [ "${#missing[@]}" -eq 0 ]; then
     printf '%sPASS%s all %d loader symbols invoked by prestart.sh are defined: %s\n' \
         "$GREEN" "$RESET" "${#called[@]}" "${called[*]}"
 else
-    printf '%sFAIL%s prestart.sh invokes loader symbols not defined by lib-hostnames.sh: %s\n' \
+    printf '%sFAIL%s prestart.sh invokes loader symbols no sourced loader defines: %s\n' \
         "$RED" "$RESET" "${missing[*]:-<none collected>}"
     FAILS=$((FAILS + 1))
 fi


### PR DESCRIPTION
A failed `Requires=` dependency does not fail the core stack — it deletes its start job. The unit never runs `ExecStart`, ends `inactive` with `Result=success`, and stays out of `systemctl --failed` while Traefik, Authelia and Homarr are all absent. Same signature as #208 and, like #208, points nowhere.

Fixes #212

## What was measured

Scratch units in `/run/systemd/system` on a HALPI2 (systemd 257), no packaged file touched:

| Experiment | Result |
|---|---|
| consumer `Requires=` a oneshot that fails | consumer `inactive`, `Result=success`, `ExecMainStartTimestamp` empty — never ran |
| same, but the oneshot has `Restart=on-failure` and succeeds on attempt 3 | oneshot reached success; consumer still never ran |
| consumer `Wants=` + `After=` a oneshot that fails | consumer `active`, started 1.8 ms after the dependency finished, failed dependency visible in `systemctl --failed` |

Row two is why adding retries to the dependency is not the fix on its own: once a start job is cancelled, nothing re-queues it.

## Changes

**`Wants=` for the two oneshots, `Requires=` only for docker.** Ordering unchanged. docker is the runtime; the oneshots produce inputs.

**prestart refuses an empty `HALOS_DOMAIN`,** because `Wants=` alone would trade a silent absence for something worse: `prestart.sh` runs `set -e` without `set -u`, so a missing domain renders an empty string into the OIDC issuer, Authelia's cookie domain and Traefik's redirects — a stack that looks healthy and whose every login fails. The guard checks the resolver's file, not the ambient variable, so a pre-upgrade `HALOS_DOMAIN` left in `runtime.env` cannot satisfy it.

**Backoff instead of a start limit.** An earlier revision capped restarts so an unbootable stack would reach `failed` and show up in `systemctl --failed`. Two problems, both raised in review: nothing re-queues a start-limit `failed` unit, so any cause lasting more than ~75 s became permanent on a headless device; and the window interacts with #214's `TimeoutStartSec=600` — systemd's rate limiter resets when an attempt arrives after the interval, so a 610 s attempt cycle never fills a 300 s burst and a *hanging* start would loop forever anyway. `RestartSteps=6` / `RestartMaxDelaySec=300` retries indefinitely at 10 s doubling to 5 min: self-healing, no 10 s spin, no coupling to the timeout.

**The resolver retries itself,** so the guard's recovery claim is true. An auto-restart of the consumer does not re-pull its dependencies — the resolver unit documents that — so without its own `Restart=` a failed resolve would leave the stack refusing forever.

**The adoption sentinel is guaranteed before compose.** `docker-compose.yml` bind-mounts it as a *file* and names the cert manager as the guarantor — a guarantee that held only while the stack required that unit. With `Wants=`, a failed cert run would let Docker create a directory there; `lib-ca.sh` repairs the host path later while the running sidecar keeps the removed inode, so adoption is never recorded and the CN-refresh gate can orphan a trust anchor the operator already installed. prestart now makes the same call the cert manager does, which preserves an existing sentinel verbatim.

Three sibling units still explained their own design in terms of the removed `Requires=`; all updated. `tests/test-packaging-contract.sh` pins the new dependency shape (its existing loops glob `debian/<pkg>.*.{service,timer,path}` and never see the main unit, so the check names it). `docs/solutions/` gets the measurement table.

## Verification on hardware

Transient failure, the case that matters — a drop-in override made the resolver fail twice then succeed, no packaged file touched:

```
11:54:19 prestart.sh: HALOS_DOMAIN_UNSET: halos-resolve-domain.service has not published /run/halos/domain.env
11:54:29 x-flaky-resolver: attempt 3, running the real resolver
11:54:29 halos-resolve-domain: HALOS_DOMAIN=halosdev.local
11:54:29 prestart.sh: Domain: halosdev.local
11:54:30 docker: Attaching to authelia, authelia-valkey, autoheal, ca-download, homarr, traefik
```

`NRestarts=1`, `ActiveState=active`, 302 from `https://localhost/`. No operator involved. Harness removed and rebooted clean afterwards: stack up, adoption sentinel still a regular file reading `pending` (preserved, not rewritten), only the unrelated `configure-ublox-marine` failure remains.

## What this does not fix

A failed `halos-manage-certs` now lets the stack start with whatever TLS material exists, and recovery depends on its timer — `OnBootSec=15min` **plus `RandomizedDelaySec=1h`**, so 15–75 minutes. Nobody has observed what Traefik serves in that window. Neither oneshot sets `TimeoutStartSec`, so a *hung* dependency still blocks the stack indefinitely — a different failure from the one fixed here.

No `VERSION` bump: latest stable is `v0.7.0+1` and `VERSION` is already 0.7.1.
