### PR TITLE
Describe this repo's actual changelog scheme in the hook and AGENTS.md

### DIFF
--- a/.github/scripts/check-changelog-edits.sh
+++ b/.github/scripts/check-changelog-edits.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 #
 # Pre-commit hook to prevent direct debian/changelog edits.
-# Changelog updates must go through ./run bumpversion which uses dch
-# to ensure proper RFC 2822 date formatting.
+# The changelog a *release* ships is generated at build time by
+# .github/scripts/generate-changelog.sh, so a hand-edit here never reaches a
+# released .deb. It does still version local ./run build packages, which is how
+# a dev build came to deploy as a downgrade (docs/solutions/2026-05-31-...).
 #
 # Bypass: SKIP_CHANGELOG_CHECK=1 git commit ...
 
@@ -10,7 +12,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-# Allow bypass for ./run bumpversion (via env var)
+# Manual override.
 if [[ "${SKIP_CHANGELOG_CHECK:-}" == "1" ]]; then
     exit 0
 fi
@@ -24,15 +26,21 @@ if [[ -n "$CHANGELOG_FILES" ]]; then
     echo "Staged changelog files:"
     echo "$CHANGELOG_FILES" | sed 's/^/  /'
     echo ""
-    echo "Why: Manual changelog edits often have RFC 2822 date formatting errors"
-    echo "(wrong weekday for date). The dch tool handles this correctly."
+    echo "Why: the changelog a release ships is written at build time by"
+    echo ".github/scripts/generate-changelog.sh, so editing the tracked file"
+    echo "changes nothing a released package carries. It does set the version of"
+    echo "local './run build' .debs, which is how a dev build once deployed as a"
+    echo "downgrade and evicted its dependents."
     echo ""
-    echo "Solution: Use './run bumpversion [patch|minor|major]' which:"
-    echo "  1. Updates VERSION file"
-    echo "  2. Uses dch to update debian/changelog with correct dates"
-    echo "  3. Commits the changes"
+    echo "Solution: drop the edit."
+    echo "  git restore --staged --worktree debian/changelog"
     echo ""
-    echo "If you need to bypass this check (e.g., fixing a changelog):"
+    echo "To open a new release cycle instead, run"
+    echo "'./run bumpversion [patch|minor|major]', which bumps VERSION and"
+    echo "commits that change -- it does not touch the changelog."
+    echo ""
+    echo "To override anyway (e.g. deliberately raising a local build's version"
+    echo "so it installs over a released one):"
     echo "  SKIP_CHANGELOG_CHECK=1 git commit ..."
     echo ""
     exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,20 @@ The `VERSION` file is a **meta-version for git tags only**. It does NOT control 
 - Controls when new releases are triggered
 - Bump this when you want a new release bundle
 
+### Changelog
+
+`debian/changelog` is **CI-generated**, not maintained by hand. The entry a
+release ships is written at build time by
+`.github/scripts/generate-changelog.sh`, and a pre-commit hook rejects edits to
+the tracked file. `./run bumpversion` bumps `VERSION` and commits it — it does
+not run `dch`, unlike the repos the workspace changelog policy describes.
+
+The tracked file is not inert, though: `tools/build-all.sh` regenerates it only
+when it is absent, so a local `./run build` stamps its `.deb` from the committed
+placeholder. That is why a dev build installs as a downgrade and can evict its
+dependents — see
+[docs/solutions/2026-05-31-deploy-downgrade-evicts-dependent-packages.md](docs/solutions/2026-05-31-deploy-downgrade-evicts-dependent-packages.md).
+
 ### App Package Versions
 
 Individual apps in `apps/` have their own versions in `metadata.yaml`. These are independent of the VERSION file.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,4 +10,4 @@ pre-commit:
 
     check-changelog:
       run: .github/scripts/check-changelog-edits.sh
-      fail_text: "Direct debian/changelog edits are not allowed. Use './run bumpversion' instead."
+      fail_text: "Direct debian/changelog edits are not allowed. See error above for details."


### PR DESCRIPTION
The pre-commit hook that blocks `debian/changelog` edits told authors to fix it with a command that does not touch the changelog.

Fixes #213

`./run bumpversion` here runs `bump2version` against a config with one target (`[bumpversion:file:VERSION]`) — no `dch`, no changelog edit. The entry a release ships is written at build time by `.github/scripts/generate-changelog.sh`; the tracked file has read `halos-core-containers (0.2.1-1)` since January.

## Changes

- The hook's "Why" and "Solution" text now describes the actual scheme, and gives the command for the case the author is actually in (`git restore --staged --worktree debian/changelog`) rather than prose.
- **`lefthook.yml`'s `fail_text` too.** lefthook prints it *after* the script's output, and it still read "Use './run bumpversion' instead." — so the corrected explanation was followed immediately by the uncorrected one, which is the last line an author reads. It now matches the sibling hook's form: "See error above for details."
- **The claim is scoped.** The first draft said an edit here "changes nothing a device ever sees". That is false for local builds: `tools/build-all.sh` regenerates only `if [ ! -f debian/changelog ]`, so `./run build` stamps its `.deb` from the tracked placeholder — the mechanism behind `docs/solutions/2026-05-31-deploy-downgrade-evicts-dependent-packages.md`, whose own mitigation is a hand edit. Both the hook text and the AGENTS.md section now say "a released package" and point at that document, and the bypass note names the case where overriding is right.
- AGENTS.md gains the Changelog section the workspace doc defers to.

## Verification

Exercised through a real blocked `git commit` with hooks installed — the path the first round missed by running the script directly, which never renders `fail_text`. Full output ends with the corrected line, exit 1. Clean tree exits 0. `bash -n` clean. The staged edit was reverted; the changelog is untouched by this branch.

## Follow-ups filed

- halos-org/halos#137 — the workspace `AGENTS.md` states the `dch` rule unconditionally; it holds for four repos and not for four others.
- #220 — untrack `debian/changelog` so local builds stop carrying a stale version, which would retire the hook and both blocks of documentation; plus pinning the tooling claims this text now makes.

No `VERSION` bump: a CI script and a docs file, neither package-affecting.
